### PR TITLE
Add cpu_context to InvocationContext

### DIFF
--- a/frida-gum/src/cpu_context.rs
+++ b/frida-gum/src/cpu_context.rs
@@ -79,4 +79,18 @@ impl<'a> CpuContext<'a> {
     #[cfg(target_arch = "aarch64")]
     cpu_accesors!(u64, pc, sp, fp, lr);
     // TODO(meme) uint8_t q[128]; uint64_t x[29];
+
+    #[cfg(target_arch = "aarch64")]
+    /// Get the value of the specified general purpose register.
+    pub fn reg(&self, index: usize) -> u64 {
+        assert!(index < 29);
+        unsafe { (*self.cpu_context).x[index] }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    /// Set the value of the specified general purpose register.
+    pub fn set_reg(&mut self, index: usize, value: u64) {
+        assert!(index < 29);
+        unsafe { (*self.cpu_context).x[index] = value };
+    }
 }

--- a/frida-gum/src/interceptor/invocation_listener.rs
+++ b/frida-gum/src/interceptor/invocation_listener.rs
@@ -4,7 +4,7 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
-use crate::NativePointer;
+use crate::{CpuContext, NativePointer};
 use frida_gum_sys as gum_sys;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
@@ -135,5 +135,10 @@ impl<'a> InvocationContext<'a> {
     /// Get the number of recursive interceptor invocations.
     pub fn depth(&self) -> u32 {
         unsafe { gum_sys::gum_invocation_context_get_depth(self.context) as u32 }
+    }
+
+    /// Get the [`CpuContext`] at the time of invocation.
+    pub fn cpu_context(&self) -> CpuContext {
+        CpuContext::from_raw(unsafe { (*self.context).cpu_context })
     }
 }


### PR DESCRIPTION
This PR adds retrieval of the `CpuContext` to `InvocationContext`, and also adds accessors for the general purpose registers on aarch64.