### PR TITLE
Add Module::find_symbol_by_name

### DIFF
--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -77,6 +77,31 @@ impl Module {
         }
     }
 
+    /// The absolute address of the symbol. In the event that no such symbol
+    /// could be found, returns NULL.
+    pub fn find_symbol_by_name(
+        module_name: Option<&str>,
+        symbol_name: &str,
+    ) -> Option<NativePointer> {
+        let symbol_name = CString::new(symbol_name).unwrap();
+
+        let ptr = match module_name {
+            None => unsafe {
+                gum_sys::gum_module_find_symbol_by_name(std::ptr::null_mut(), symbol_name.as_ptr())
+            },
+            Some(name) => unsafe {
+                let module_name = CString::new(name).unwrap();
+                gum_sys::gum_module_find_symbol_by_name(module_name.as_ptr(), symbol_name.as_ptr())
+            },
+        } as *mut c_void;
+
+        if ptr.is_null() {
+            None
+        } else {
+            Some(NativePointer(ptr))
+        }
+    }
+
     /// Returns the base address of the specified module. In the event that no
     /// such module could be found, returns NULL.
     pub fn find_base_address(module_name: &str) -> NativePointer {


### PR DESCRIPTION
The `Module` struct only exposes `find_export_by_name`. Gum also provides `find_symbol_by_name`, expose that too to resolve non-exported symbols.