### PR TITLE
Added Gum parameter and removed Default for ModuleMap

### DIFF
--- a/frida-gum/src/module_map.rs
+++ b/frida-gum/src/module_map.rs
@@ -8,7 +8,7 @@
 use frida_gum_sys as gum_sys;
 use std::{ffi::CStr, os::raw::c_void, path::Path};
 
-use crate::MemoryRange;
+use crate::{Gum, MemoryRange};
 
 struct SaveModuleDetailsByNameContext {
     name: String,
@@ -147,12 +147,12 @@ impl ModuleMap {
     }
 
     /// Create a new [`ModuleMap`]
-    pub fn new() -> Self {
+    pub fn new(_gum: &Gum) -> Self {
         Self::from_raw(unsafe { gum_sys::gum_module_map_new() })
     }
 
     /// Create a new [`ModuleMap`] with a filter function
-    pub fn new_with_filter(filter: &mut dyn FnMut(ModuleDetails) -> bool) -> Self {
+    pub fn new_with_filter(_gum: &Gum, filter: &mut dyn FnMut(ModuleDetails) -> bool) -> Self {
         unsafe extern "C" fn module_map_filter(
             details: *const gum_sys::_GumModuleDetails,
             callback: *mut c_void,
@@ -174,8 +174,8 @@ impl ModuleMap {
     }
 
     /// Create a new [`ModuleMap`] from a list of names
-    pub fn new_from_names(names: &[&str]) -> Self {
-        Self::new_with_filter(&mut |details: ModuleDetails| {
+    pub fn new_from_names(gum: &Gum, names: &[&str]) -> Self {
+        Self::new_with_filter(gum, &mut |details: ModuleDetails| {
             for name in names {
                 if (name.starts_with('/') && details.path().eq(name))
                     || (name.contains('/')
@@ -222,12 +222,6 @@ impl ModuleMap {
     /// Update the [`ModuleMap`]. This function must be called before using find.
     pub fn update(&mut self) {
         unsafe { gum_sys::gum_module_map_update(self.module_map) }
-    }
-}
-
-impl Default for ModuleMap {
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
When playing around with frida-gum, I've found quite an interesting bug:

Sometimes, when I used `ModuleMap`, the program would crash, but other times, it worked as expected. I've managed to narrow it down to the following case: if `ModuleMap` is the first thing to be initialized, the program fails, but if `Interceptor`
or `Stalker` are initialized before it, everything is ok. 

Then I realized that `ModuleMap` is also a `GObject`, like `Interceptor` and `Stalker`, so if the `gum_init_embedded` is not called before trying to use it, the following line will segfault (since the runtime is not initalized):

https://github.com/frida/frida-gum/blob/55f8dd6ae69fc3d5370c2885c344aab38a894b47/gum/gummodulemap.c#L84

The fix is to add the `Gum` parameter to all constructors, which sadly means that `Default` has to be removed.