### PR TITLE
Fix Module::find_symbol_by_name to require a module name

### DIFF
--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -79,10 +79,7 @@ impl Module {
 
     /// The absolute address of the symbol. In the event that no such symbol
     /// could be found, returns NULL.
-    pub fn find_symbol_by_name(
-        module_name: &str,
-        symbol_name: &str,
-    ) -> Option<NativePointer> {
+    pub fn find_symbol_by_name(module_name: &str, symbol_name: &str) -> Option<NativePointer> {
         let symbol_name = CString::new(symbol_name).unwrap();
 
         let module_name = CString::new(module_name).unwrap();

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -80,19 +80,14 @@ impl Module {
     /// The absolute address of the symbol. In the event that no such symbol
     /// could be found, returns NULL.
     pub fn find_symbol_by_name(
-        module_name: Option<&str>,
+        module_name: &str,
         symbol_name: &str,
     ) -> Option<NativePointer> {
         let symbol_name = CString::new(symbol_name).unwrap();
 
-        let ptr = match module_name {
-            None => unsafe {
-                gum_sys::gum_module_find_symbol_by_name(std::ptr::null_mut(), symbol_name.as_ptr())
-            },
-            Some(name) => unsafe {
-                let module_name = CString::new(name).unwrap();
-                gum_sys::gum_module_find_symbol_by_name(module_name.as_ptr(), symbol_name.as_ptr())
-            },
+        let module_name = CString::new(module_name).unwrap();
+        let ptr = unsafe {
+            gum_sys::gum_module_find_symbol_by_name(module_name.as_ptr(), symbol_name.as_ptr())
         } as *mut c_void;
 
         if ptr.is_null() {


### PR DESCRIPTION
Gum's `gum_module_find_symbol_by_name()`, unlike
`gum_module_find_export_by_name()`, requires its `module_name` argument to
be non-NULL.

I overlooked this when I submitted my previous PR (#31) to expose `Module::find_symbol_by_name`.
This PR fixes that.