### PR TITLE
Add methods to generate backtraces from a CpuContext

### DIFF
--- a/frida-gum/src/cpu_context.rs
+++ b/frida-gum/src/cpu_context.rs
@@ -93,4 +93,18 @@ impl<'a> CpuContext<'a> {
         assert!(index < 29);
         unsafe { (*self.cpu_context).x[index] = value };
     }
+
+    #[cfg(all(feature = "backtrace", not(target_os = "windows")))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "backtrace")))]
+    /// Get an accurate backtrace from this CPU context.
+    pub fn backtrace_accurate(&self) -> Vec<usize> {
+        crate::Backtracer::accurate_with_context(unsafe { &*self.cpu_context })
+    }
+
+    #[cfg(all(feature = "backtrace", not(target_os = "windows")))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "backtrace")))]
+    /// Get a fuzzy backtrace from this CPU context.
+    pub fn backtrace_fuzzy(&self) -> Vec<usize> {
+        crate::Backtracer::fuzzy_with_context(unsafe { &*self.cpu_context })
+    }
 }


### PR DESCRIPTION
The `backtracer` module can generate backtraces on its own, or from a provided `GumCpuContext` (using `accurate_with_context`, `fuzzy_with_context`).
However, there doesn't seem to be an easy way to get one such `gum_sys::GumCpuContext` from a `gum::CpuContext`: there's one inside, but it's not exposed.
So this PR adds the `CpuContext::backtrace_accurate` and `CpuContext::backtrace_fuzzy` methods to generate backtraces using the `CpuContext`'s internal `GumCpuContext`.