### PR TITLE
Bump capstone, capstone-sys version

### DIFF
--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -20,8 +20,8 @@ num-derive = "0.3.3"
 num-traits = "0.2.14"
 paste = "1"
 libc = { version = "0.2.93", optional = true }
-capstone = "0.10.0"
-capstone-sys = "0.14.0"
+capstone = "0.11.0"
+capstone-sys = "0.15.0"
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR bumps capstone version
capstone: 0.10.0 -> 0.11.0
capstone-sys: 0.14.0 -> 0.15.0