### PR TITLE
Added module debug_symbol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "examples/gum/stalker",
     "examples/gum/hook_open",
     "examples/gum/hook_instruction",
+    "examples/gum/debug_symbol",
     "examples/core/hello",
     "examples/core/console_log",
 ]

--- a/examples/gum/debug_symbol/Cargo.toml
+++ b/examples/gum/debug_symbol/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "debug-symbol"
+version = "0.1.0"
+authors = ["Tal Liberman <talliberman@users.noreply.github.com>"]
+edition = "2018"
+license = "MIT"
+
+[dependencies]
+frida-gum = { path = "../../../frida-gum", features = ["invocation-listener"]}
+lazy_static = "1.4"

--- a/examples/gum/debug_symbol/src/main.rs
+++ b/examples/gum/debug_symbol/src/main.rs
@@ -1,0 +1,34 @@
+use frida_gum::DebugSymbol;
+use frida_gum::{Gum, Module};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref GUM: Gum = unsafe { Gum::obtain() };
+}
+
+fn main() {
+    lazy_static::initialize(&GUM);
+
+    let symbol = Module::find_export_by_name(None, "mmap").unwrap();
+    let symbol_details = DebugSymbol::from_address(symbol).unwrap();
+    println!(
+        "address={:#x?} module_name={:?} symbol_name={:?} file_name={:?} line_number={:?}",
+        symbol_details.address(),
+        symbol_details.module_name(),
+        symbol_details.symbol_name(),
+        symbol_details.file_name(),
+        symbol_details.line_number()
+    );
+    println!("{:?}", symbol_details);
+
+    let symbol_details = DebugSymbol::from_name("open").unwrap();
+    println!(
+        "address={:#x?} module_name={:?} symbol_name={:?} file_name={:?} line_number={:?}",
+        symbol_details.address(),
+        symbol_details.module_name(),
+        symbol_details.symbol_name(),
+        symbol_details.file_name(),
+        symbol_details.line_number()
+    );
+    println!("{:?}", symbol_details);
+}

--- a/frida-gum/src/debug_symbol.rs
+++ b/frida-gum/src/debug_symbol.rs
@@ -1,0 +1,99 @@
+use std::borrow::Borrow;
+use std::convert::TryInto;
+use std::fmt;
+use std::mem::MaybeUninit;
+use std::{
+    ffi::{CStr, CString},
+    str::Utf8Error,
+};
+
+use frida_gum_sys as gum_sys;
+use gum_sys::{gum_find_function, gum_symbol_details_from_address, GumDebugSymbolDetails};
+
+use crate::NativePointer;
+
+pub struct Symbol {
+    gum_debug_symbol_details: GumDebugSymbolDetails,
+}
+
+impl fmt::Debug for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Symbol")
+            .field("address", &self.address())
+            .field("module_name", &self.module_name())
+            .field("symbol_name", &self.symbol_name())
+            .field("file_name", &self.file_name())
+            .field("line_number", &self.line_number())
+            .finish()
+    }
+}
+
+impl Symbol {
+    /// Address that this symbol is for.
+    pub fn address(&self) -> usize {
+        self.gum_debug_symbol_details.address.try_into().unwrap()
+    }
+
+    /// Name of the symbol
+    pub fn module_name(&self) -> Result<&str, Utf8Error> {
+        unsafe { CStr::from_ptr(self.gum_debug_symbol_details.module_name.as_ptr()) }.to_str()
+    }
+
+    /// Module name owning this symbol
+    pub fn symbol_name(&self) -> Result<&str, Utf8Error> {
+        unsafe { CStr::from_ptr(self.gum_debug_symbol_details.symbol_name.as_ptr()) }.to_str()
+    }
+
+    /// File name owning this symbol
+    pub fn file_name(&self) -> Result<&str, Utf8Error> {
+        unsafe { CStr::from_ptr(self.gum_debug_symbol_details.file_name.as_ptr()) }.to_str()
+    }
+
+    /// Line number in file_name
+    pub fn line_number(&self) -> u32 {
+        self.gum_debug_symbol_details.line_number
+    }
+}
+
+pub struct DebugSymbol {}
+
+impl DebugSymbol {
+    /// Get debug symbol details for address
+    pub fn from_address<B: Borrow<NativePointer>>(address: B) -> Option<Symbol> {
+        let mut gum_symbol_details: GumDebugSymbolDetails =
+            unsafe { MaybeUninit::zeroed().assume_init() };
+        match unsafe {
+            gum_symbol_details_from_address(
+                address.borrow().into(),
+                &mut gum_symbol_details as *mut _,
+            )
+        } {
+            1 => Some(Symbol {
+                gum_debug_symbol_details: gum_symbol_details,
+            }),
+            0 => None,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn find_function<S: AsRef<str>>(name: S) -> Option<NativePointer> {
+        match CString::new(name.as_ref()) {
+            Ok(name) => {
+                let address = unsafe { gum_find_function(name.into_raw()) };
+                if address.is_null() {
+                    None
+                } else {
+                    Some(NativePointer(address))
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn from_name<S: AsRef<str>>(name: S) -> Option<Symbol> {
+        match Self::find_function(name) {
+            Some(address) => Self::from_address(address),
+            None => None,
+        }
+    }
+}

--- a/frida-gum/src/debug_symbol.rs
+++ b/frida-gum/src/debug_symbol.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::convert::TryInto;
 use std::fmt;
 use std::mem::MaybeUninit;
@@ -59,12 +58,12 @@ pub struct DebugSymbol {}
 
 impl DebugSymbol {
     /// Get debug symbol details for address
-    pub fn from_address<B: Borrow<NativePointer>>(address: B) -> Option<Symbol> {
+    pub fn from_address<N: AsRef<NativePointer>>(address: N) -> Option<Symbol> {
         let mut gum_symbol_details: GumDebugSymbolDetails =
             unsafe { MaybeUninit::zeroed().assume_init() };
         match unsafe {
             gum_symbol_details_from_address(
-                address.borrow().into(),
+                address.as_ref().into(),
                 &mut gum_symbol_details as *mut _,
             )
         } {

--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -83,6 +83,9 @@ pub use memory_range::*;
 mod range_details;
 pub use range_details::*;
 
+mod debug_symbol;
+pub use debug_symbol::*;
+
 #[cfg(all(feature = "backtrace", not(target_os = "windows")))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "backtrace")))]
 mod backtracer;
@@ -118,6 +121,18 @@ impl NativePointer {
     /// Check if the pointer is NULL.
     pub fn is_null(&self) -> bool {
         self.0.is_null()
+    }
+}
+
+impl From<&NativePointer> for *mut c_void {
+    fn from(other: &NativePointer) -> Self {
+        other.0
+    }
+}
+
+impl From<NativePointer> for *mut c_void {
+    fn from(other: NativePointer) -> Self {
+        other.0
     }
 }
 

--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -152,3 +152,9 @@ impl TryFrom<NativePointer> for String {
         }
     }
 }
+
+impl AsRef<NativePointer> for NativePointer {
+    fn as_ref(&self) -> &NativePointer {
+        self
+    }
+}


### PR DESCRIPTION
Added support for calling Frida's `gum_symbol_details_from_address` function by creating a new module `symbol_util`.

The intention is for `symbol_util.rs` to mirror `gum/gumsymbolutil.h`.

There's a new struct `DebugSymbolDetails` to wrap Frida's `GumDebugSymbolDetails`, along with relevant methods for extracting its fields (`address`, `module_name`, `symbol_name`, `file_name`, `line_number`).