### PR TITLE
Expose modules in core

### DIFF
--- a/frida/src/device.rs
+++ b/frida/src/device.rs
@@ -4,6 +4,8 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+//! Device helper.
+
 use frida_sys::_FridaDevice;
 use std::ffi::CStr;
 use std::marker::PhantomData;

--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -4,6 +4,8 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+//! Used to enumerate all devices.
+
 use frida_sys::_FridaDeviceManager;
 use std::marker::PhantomData;
 

--- a/frida/src/lib.rs
+++ b/frida/src/lib.rs
@@ -14,22 +14,22 @@
 
 use std::ffi::CStr;
 
-mod device;
+pub mod device;
 pub use device::*;
 
-mod device_manager;
+pub mod device_manager;
 pub use device_manager::*;
 
 mod error;
 pub use error::Error;
 
-mod process;
+pub mod process;
 pub use process::*;
 
-mod script;
+pub mod script;
 pub use script::*;
 
-mod session;
+pub mod session;
 pub use session::*;
 
 #[doc(hidden)]

--- a/frida/src/process.rs
+++ b/frida/src/process.rs
@@ -4,6 +4,8 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+//! Process helper.
+
 use frida_sys::_FridaProcess;
 use std::ffi::CStr;
 use std::marker::PhantomData;

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -4,6 +4,9 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+//! Script helper.
+//! Used to inject a Frida script.
+
 use frida_sys::{FridaScriptOptions, _FridaScript};
 use std::marker::PhantomData;
 use std::{

--- a/frida/src/session.rs
+++ b/frida/src/session.rs
@@ -4,6 +4,8 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+//! Session helper.
+
 use frida_sys::_FridaSession;
 use std::ffi::CString;
 use std::marker::PhantomData;


### PR DESCRIPTION
Hey,
During my last push, I forgot to expose the modules, which makes the core unusable.
The comments are not precise but it just allows to use the library.