### PR TITLE
IA-32 support in Gum

### DIFF
--- a/frida-gum/src/memory_range.rs
+++ b/frida-gum/src/memory_range.rs
@@ -73,7 +73,12 @@ impl MemoryRange {
     pub fn scan(&self, pattern: &MatchPattern) -> Vec<ScanResult> {
         let mut results = Vec::new();
         unsafe {
-            extern "C" fn callback(address: u64, size: u64, user_data: *mut c_void) -> i32 {
+            #[cfg(target_pointer_width = "64")]
+            type TargetSize = u64;
+            #[cfg(target_pointer_width = "32")]
+            type TargetSize = u32;
+
+            extern "C" fn callback(address: u64, size: TargetSize, user_data: *mut c_void) -> i32 {
                 let results: &mut Vec<ScanResult> =
                     unsafe { &mut *(user_data as *mut Vec<ScanResult>) };
                 results.push(ScanResult {

--- a/frida-gum/src/module_map.rs
+++ b/frida-gum/src/module_map.rs
@@ -50,7 +50,7 @@ unsafe extern "C" fn save_module_details_by_address(
     let mut context = &mut *(context as *mut SaveModuleDetailsByAddressContext);
     let range = (*details).range;
     let start = (*range).base_address as u64;
-    let end = start + (*range).size;
+    let end = start + (*range).size as u64;
     if start <= context.address && context.address < end {
         context.details = gum_sys::gum_module_details_copy(details);
         return 0;

--- a/frida-gum/src/range_details.rs
+++ b/frida-gum/src/range_details.rs
@@ -54,7 +54,7 @@ impl<'a> FileMapping<'a> {
 
     /// The size of the mapping.
     pub fn size(&self) -> u64 {
-        unsafe { (*self.file_mapping).size }
+        unsafe { (*self.file_mapping).size as u64 }
     }
 }
 
@@ -70,7 +70,7 @@ unsafe extern "C" fn save_range_details_by_address(
     let mut context = &mut *(context as *mut SaveRangeDetailsByAddressContext);
     let range = (*details).range;
     let start = (*range).base_address as u64;
-    let end = start + (*range).size;
+    let end = start + (*range).size as u64;
     if start <= context.address && context.address < end {
         context.details = details;
         return 0;

--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -130,7 +130,7 @@ impl<'a> StalkerOutput<'a> {
     /// Obtain an [`crate::instruction_writer::InstructionWriter`] for inserting into the stream.
     pub fn writer(&self) -> TargetInstructionWriter {
         unsafe {
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
             let writer = TargetInstructionWriter::from_raw((*self.output).writer.x86);
             #[cfg(target_arch = "aarch64")]
             let writer = TargetInstructionWriter::from_raw((*self.output).writer.arm64);


### PR DESCRIPTION
Closes #63.

The changes build fine on Windows x86 and x64 MSVC targets, but I haven't tested more than that. Also, I'm not sure how I would go about adding the 32-bit targets to CI.