### PR TITLE
Undo special linux-arm64 case.

### DIFF
--- a/frida-gum-sys/src/lib.rs
+++ b/frida-gum-sys/src/lib.rs
@@ -20,7 +20,6 @@ pub use bindings::*;
     target_os = "macos",
     target_os = "ios",
     target_os = "windows",
-    target_os = "android",
-    all(target_os = "linux", target_arch = "aarch64")
+    target_os = "android"
 )))]
 pub use _frida_g_object_unref as g_object_unref;


### PR DESCRIPTION
After the update to frida 16, excluding that line on linux+arm64 is not necessary anymore, and in fact after updating to frida 16 `frida-gum` cannot build on linux+arm64 anymore.

This works:
```
frida-gum = { git = "https://github.com/frida/frida-rust", rev = "0226bf9ca8171cba864024dfd21364e7b1833392", features = ["auto-download"] } # Fix Linux/aarch64
```

This fails:
```
frida-gum = { git = "https://github.com/frida/frida-rust", rev = "9976bced744b0b4ad658f60825eee3083243cdbe", features = ["auto-download"] } # Update Frida to 16.0.2
```

This works again:
```
frida-gum = { git = "https://github.com/t4lz/frida-rust", branch = "linux-arm-frida16", features = ["auto-download"] }
```

Sorry for that.