### PR TITLE
Add support for allowing stalker to be configured

### DIFF
--- a/examples/gum/stalker_observer/Cargo.toml
+++ b/examples/gum/stalker_observer/Cargo.toml
@@ -7,6 +7,6 @@ license = "wxWindows"
 publish = false
 
 [dependencies]
-frida-gum = { path = "../../../frida-gum", features = ["event-sink", "invocation-listener", "stalker-observer"] }
+frida-gum = { path = "../../../frida-gum", features = ["event-sink", "invocation-listener", "stalker-observer", "stalker-params"] }
 frida-gum-sys = { path = "../../../frida-gum-sys" }
 lazy_static = "1.4"

--- a/frida-gum-sys/Cargo.toml
+++ b/frida-gum-sys/Cargo.toml
@@ -12,6 +12,7 @@ auto-download = ["frida-build"]
 event-sink = ["cc"]
 invocation-listener = ["cc"]
 stalker-observer = ["cc"]
+stalker-params = ["cc"]
 
 [build-dependencies]
 bindgen = "0.61.0"

--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -30,6 +30,12 @@ fn main() {
         println!("cargo:rerun-if-changed=stalker_observer.h");
     }
 
+    #[cfg(feature = "stalker-params")]
+    {
+        println!("cargo:rerun-if-changed=stalker_params.c");
+        println!("cargo:rerun-if-changed=stalker_params.h");
+    }
+
     println!(
         "cargo:rustc-link-search={}",
         env::var("CARGO_MANIFEST_DIR").unwrap()
@@ -67,6 +73,7 @@ fn main() {
         .header("invocation_listener.h")
         .header("probe_listener.h")
         .header("stalker_observer.h")
+        .header("stalker_params.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .generate_comments(false)
         .layout_tests(false)
@@ -143,7 +150,7 @@ fn main() {
 
         #[cfg(feature = "auto-download")]
         #[allow(unused_mut)]
-        let mut builder = builder.include(include_dir);
+        let mut builder = builder.include(include_dir.clone());
 
         #[cfg(not(feature = "auto-download"))]
         let builder = if std::env::var("DOCS_RS").is_ok() {
@@ -156,6 +163,27 @@ fn main() {
             .file("stalker_observer.c")
             .opt_level(3)
             .compile("stalker_observer");
+    }
+
+    #[cfg(feature = "stalker-params")]
+    {
+        let mut builder = cc::Build::new();
+
+        #[cfg(feature = "auto-download")]
+        #[allow(unused_mut)]
+        let mut builder = builder.include(include_dir);
+
+        #[cfg(not(feature = "auto-download"))]
+        let builder = if std::env::var("DOCS_RS").is_ok() {
+            builder.include("include")
+        } else {
+            &mut builder
+        };
+
+        builder
+            .file("stalker_params.c")
+            .opt_level(3)
+            .compile("stalker_params");
     }
 
     #[cfg(target_os = "windows")]

--- a/frida-gum-sys/stalker_params.c
+++ b/frida-gum-sys/stalker_params.c
@@ -1,0 +1,19 @@
+#include "stalker_params.h"
+
+#if defined (_M_ARM64) || defined (__aarch64__)
+GumStalker *
+gum_stalker_new_with_params (guint stalker_ic_entries)
+{
+  GumStalker * stalker = g_object_new(GUM_TYPE_STALKER, "ic-entries",
+    stalker_ic_entries, NULL);
+  return stalker;
+}
+#elif defined (_M_IX86) || defined (__i386__) || defined (_M_X64) || defined (__x86_64__)
+GumStalker *
+gum_stalker_new_with_params (guint stalker_ic_entries, guint stalker_adjacent_blocks)
+{
+  GumStalker * stalker = g_object_new(GUM_TYPE_STALKER, "ic-entries",
+    stalker_ic_entries, "adjacent-blocks", stalker_adjacent_blocks, NULL);
+  return stalker;
+}
+#endif

--- a/frida-gum-sys/stalker_params.h
+++ b/frida-gum-sys/stalker_params.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "frida-gum.h"
+
+G_BEGIN_DECLS
+
+#if defined (_M_ARM64) || defined (__aarch64__)
+GumStalker * gum_stalker_new_with_params (guint stalker_ic_entries);
+#elif defined (__x86_64__)
+GumStalker * gum_stalker_new_with_params (guint stalker_ic_entries, guint stalker_adjacent_blocks);
+#endif
+
+G_END_DECLS

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -13,6 +13,7 @@ backtrace = ["libc"]
 event-sink = ["frida-gum-sys/event-sink"]
 invocation-listener = ["frida-gum-sys/invocation-listener"]
 stalker-observer = ["frida-gum-sys/stalker-observer"]
+stalker-params = ["frida-gum-sys/stalker-params"]
 
 [dependencies]
 frida-gum-sys = { path = "../frida-gum-sys", version = "0.6.0" }
@@ -32,5 +33,5 @@ lazy_static = "1"
 maintenance = { status = "experimental" }
 
 [package.metadata.docs.rs]
-features = ["event-sink", "invocation-listener", "stalker-observer"]
+features = ["event-sink", "invocation-listener", "stalker-observer", "stalker-params"]
 rustdoc-args = ["--cfg", "doc_cfg"]

--- a/frida-gum/src/stalker.rs
+++ b/frida-gum/src/stalker.rs
@@ -116,6 +116,44 @@ impl<'a> Stalker<'a> {
         }
     }
 
+    /// Create a new Stalker with parameters
+    ///
+    /// This call has the overhead of checking if the Stalker is
+    /// available on the current platform, as creating a Stalker on an
+    /// unsupported platform results in unwanted behaviour.
+    #[cfg(all(target_arch = "aarch64", feature = "stalker-params"))]
+    pub fn new_with_params<'b>(gum: &'b Gum, ic_entries: u32) -> Stalker
+    where
+        'b: 'a,
+    {
+        assert!(Self::is_supported(gum));
+
+        Stalker {
+            stalker: unsafe { frida_gum_sys::gum_stalker_new_with_params(ic_entries) },
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create a new Stalker with parameters
+    ///
+    /// This call has the overhead of checking if the Stalker is
+    /// available on the current platform, as creating a Stalker on an
+    /// unsupported platform results in unwanted behaviour.
+    #[cfg(all(target_arch = "x86_64", feature = "stalker-params"))]
+    pub fn new_with_params<'b>(gum: &'b Gum, ic_entries: u32, adjacent_blocks: u32) -> Stalker
+    where
+        'b: 'a,
+    {
+        assert!(Self::is_supported(gum));
+
+        Stalker {
+            stalker: unsafe {
+                frida_gum_sys::gum_stalker_new_with_params(ic_entries, adjacent_blocks)
+            },
+            phantom: PhantomData,
+        }
+    }
+
     /// Exclude a range of address from the Stalker engine.
     ///
     /// This exclusion will prevent the Stalker from tracing into the memory range,


### PR DESCRIPTION
A little commit to allow access to the extended properties for fine-tuning the stalker engine when calling its constructor.