### PR TITLE
Update bindgen to 0.63

### DIFF
--- a/frida-gum-sys/Cargo.toml
+++ b/frida-gum-sys/Cargo.toml
@@ -14,7 +14,7 @@ invocation-listener = ["cc"]
 stalker-observer = ["cc"]
 
 [build-dependencies]
-bindgen = "0.61.0"
+bindgen = "0.63"
 cc = { version = "1.0", optional = true }
 frida-build = { path = "../frida-build", version = "0.2.1", optional = true }
 

--- a/frida-sys/Cargo.toml
+++ b/frida-sys/Cargo.toml
@@ -11,7 +11,7 @@ description = "Rust generated bindings for Frida"
 auto-download = ["frida-build"]
 
 [build-dependencies]
-bindgen = "0.61.0"
+bindgen = "0.63"
 frida-build = { path = "../frida-build", version = "0.2.1", optional = true }
 
 [badges]


### PR DESCRIPTION
The current bindgen version (0.61) is buggy on many systems and clang versions leading to parsing errors related to anonymous structs and unions