### PR TITLE
Implement standard traits for NativePointer

### DIFF
--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -115,6 +115,8 @@ impl Drop for Gum {
     }
 }
 
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct NativePointer(pub *mut c_void);
 
 impl NativePointer {


### PR DESCRIPTION
Implement Copy, Clone, Hash, and Eq for NativePointers. Additionally, make NativePointer #[repr(transparent)], so it can be used in FFI just like the underlying `*mut c_void`.