### PR TITLE
Changes to frida-gum to support nostd

### DIFF
--- a/frida-gum-sys/Cargo.toml
+++ b/frida-gum-sys/Cargo.toml
@@ -13,9 +13,10 @@ event-sink = ["cc"]
 invocation-listener = ["cc"]
 stalker-observer = ["cc"]
 stalker-params = ["cc"]
+nostd=[]
 
 [build-dependencies]
-bindgen = "0.63"
+bindgen = { version = "0.63" }
 cc = { version = "1.0", optional = true }
 frida-build = { path = "../frida-build", version = "0.2.1", optional = true }
 

--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -55,7 +55,11 @@ fn main() {
         println!("cargo:rustc-link-lib=pthread");
     }
 
+    #[cfg(not(feature = "nostd"))]
     let bindings = bindgen::Builder::default();
+
+    #[cfg(feature = "nostd")]
+    let bindings = bindgen::Builder::default().use_core();
 
     #[cfg(feature = "auto-download")]
     let bindings = bindings.clang_arg(format!("-I{include_dir}"));

--- a/frida-gum-sys/src/lib.rs
+++ b/frida-gum-sys/src/lib.rs
@@ -3,7 +3,7 @@
  *
  * Licence: wxWindows Library Licence, Version 3.1
  */
-
+#![cfg_attr(feature = "nostd", no_std)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -8,23 +8,28 @@ repository = "https://github.com/frida/frida-rust"
 description = "Rust bindings for Frida Gum"
 
 [features]
+default = ["thiserror", "no-std-compat/std"]
 auto-download = ["frida-gum-sys/auto-download"]
 backtrace = ["libc"]
 event-sink = ["frida-gum-sys/event-sink"]
 invocation-listener = ["frida-gum-sys/invocation-listener"]
+nostd = ["frida-gum-sys/nostd", "no-std-compat", "thiserror-no-std", "cstr_core"]
 stalker-observer = ["frida-gum-sys/stalker-observer"]
 stalker-params = ["frida-gum-sys/stalker-params"]
 
 [dependencies]
 frida-gum-sys = { path = "../frida-gum-sys", version = "0.6.0" }
-num = "0.3.1"
-num-derive = "0.3.3"
-num-traits = "0.2.14"
-paste = "1"
-libc = { version = "0.2.93", optional = true }
-capstone = "0.11.0"
-capstone-sys = "0.15.0"
-thiserror = "1"
+num = { version = "0.3.1", default-features = false }
+num-derive = { version = "0.3.3", default-features = false }
+num-traits = { version = "0.2.14", default-features = false }
+paste = { version = "1", default-features = false }
+libc = { version = "0.2.93", optional = true, default-features = false }
+capstone = { version = "0.11.0", default-features = false }
+capstone-sys = { version = "0.15.0", default-features = false }
+thiserror = { version = "1", optional = true }
+no-std-compat = {version = "0.4.1", optional = true, features = ["alloc"], default-features = false }
+thiserror-no-std = {version = "2.0.2", optional = true }
+cstr_core = {version = "0.2.6", optional = true, features = ["alloc"], default-features = false }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/frida-gum/src/backtracer.rs
+++ b/frida-gum/src/backtracer.rs
@@ -8,7 +8,7 @@
 //! Backtracer helpers.
 //!
 
-use frida_gum_sys as gum_sys;
+use {frida_gum_sys as gum_sys, std::prelude::v1::*};
 
 // The following function is not exposed through the `frida-gum.h` header, so we don't have an
 // auto-generated binding for it. This may change in a future version.

--- a/frida-gum/src/cpu_context.rs
+++ b/frida-gum/src/cpu_context.rs
@@ -4,11 +4,18 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
-use frida_gum_sys as gum_sys;
-use gum_sys::GumCpuContext;
-use paste::paste;
-use std::marker::PhantomData;
+use {
+    frida_gum_sys as gum_sys,
+    gum_sys::GumCpuContext,
+    paste::paste,
+    std::{marker::PhantomData, prelude::v1::*},
+};
+
+#[cfg(not(feature = "nostd"))]
 use std::os::raw::c_void;
+
+#[cfg(feature = "nostd")]
+use core::ffi::c_void;
 
 macro_rules! cpu_accesors {
     ($reg:ty,$($name:ident),*) => {

--- a/frida-gum/src/debug_symbol.rs
+++ b/frida-gum/src/debug_symbol.rs
@@ -1,10 +1,10 @@
-use std::convert::TryInto;
-use std::fmt;
-use std::mem::MaybeUninit;
-use std::{
-    ffi::{CStr, CString},
-    str::Utf8Error,
-};
+use std::{convert::TryInto, ffi::CStr, fmt, mem::MaybeUninit, str::Utf8Error};
+
+#[cfg(not(feature = "nostd"))]
+use std::ffi::CString;
+
+#[cfg(feature = "nostd")]
+use {cstr_core::CString, std::prelude::v1::*};
 
 use frida_gum_sys as gum_sys;
 use gum_sys::{gum_find_function, gum_symbol_details_from_address, GumDebugSymbolDetails};

--- a/frida-gum/src/error.rs
+++ b/frida-gum/src/error.rs
@@ -4,7 +4,11 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
+#[cfg(not(feature = "nostd"))]
 use thiserror::Error;
+
+#[cfg(feature = "nostd")]
+use thiserror_no_std::Error;
 
 /// Custom `Error` for Frida
 #[derive(Error, Debug)]

--- a/frida-gum/src/instruction_writer/x86_64/writer.rs
+++ b/frida-gum/src/instruction_writer/x86_64/writer.rs
@@ -5,6 +5,9 @@ use {
     std::{convert::TryInto, ffi::c_void},
 };
 
+#[cfg(feature = "nostd")]
+use std::prelude::v1::*;
+
 /// The x86/x86_64 instruction writer.
 pub struct X86InstructionWriter {
     pub(crate) writer: *mut gum_sys::_GumX86Writer,

--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -44,7 +44,7 @@
 //!     stalker.unfollow_me();
 //! }
 //! ```
-
+#![cfg_attr(feature = "nostd", no_std)]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![deny(warnings)]
 #![allow(clippy::needless_doctest_main)]
@@ -55,9 +55,20 @@ extern crate num;
 #[macro_use]
 extern crate num_derive;
 
+#[cfg(feature = "nostd")]
+extern crate no_std_compat as std;
+
 use std::convert::TryFrom;
 use std::ffi::CStr;
+
+#[cfg(not(feature = "nostd"))]
 use std::os::raw::{c_char, c_void};
+
+#[cfg(feature = "nostd")]
+use {
+    core::ffi::{c_char, c_void},
+    std::prelude::v1::*,
+};
 
 pub mod stalker;
 

--- a/frida-gum/src/memory_range.rs
+++ b/frida-gum/src/memory_range.rs
@@ -5,8 +5,12 @@
  */
 
 use frida_gum_sys as gum_sys;
-use std::ffi::CString;
-use std::os::raw::c_void;
+
+#[cfg(not(feature = "nostd"))]
+use std::{ffi::CString, os::raw::c_void};
+
+#[cfg(feature = "nostd")]
+use {core::ffi::c_void, cstr_core::CString, std::prelude::v1::*};
 
 use crate::NativePointer;
 

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -15,8 +15,12 @@
 
 use frida_gum_sys as gum_sys;
 use std::convert::TryInto;
-use std::ffi::CString;
-use std::os::raw::c_void;
+
+#[cfg(not(feature = "nostd"))]
+use std::{ffi::CString, os::raw::c_void};
+
+#[cfg(feature = "nostd")]
+use {core::ffi::c_void, cstr_core::CString, std::prelude::v1::*};
 
 use frida_gum_sys::{gboolean, gpointer, GumExportDetails, GumModuleDetails, GumSymbolDetails};
 

--- a/frida-gum/src/module_map.rs
+++ b/frida-gum/src/module_map.rs
@@ -11,10 +11,17 @@
 )]
 
 use frida_gum_sys as gum_sys;
-use std::{ffi::CStr, os::raw::c_void, path::Path};
+use std::ffi::CStr;
+
+#[cfg(not(feature = "nostd"))]
+use std::{os::raw::c_void, path::Path};
+
+#[cfg(feature = "nostd")]
+use {core::ffi::c_void, std::prelude::v1::*};
 
 use crate::{Gum, MemoryRange};
 
+#[cfg(not(feature = "nostd"))]
 struct SaveModuleDetailsByNameContext {
     name: String,
     details: *mut gum_sys::GumModuleDetails,
@@ -25,6 +32,7 @@ struct SaveModuleDetailsByAddressContext {
     details: *mut gum_sys::GumModuleDetails,
 }
 
+#[cfg(not(feature = "nostd"))]
 unsafe extern "C" fn save_module_details_by_name(
     details: *const gum_sys::GumModuleDetails,
     context: *mut c_void,
@@ -77,6 +85,7 @@ impl ModuleDetails {
     /// Get a new [`ModuleDetails`] instance for the module matching the given name. The name may
     /// be a full path, in which case the matching module must have the same full path, or a
     /// file name, in which case only the file name portion of the module must match.
+    #[cfg(not(feature = "nostd"))]
     pub fn with_name(name: String) -> Option<Self> {
         let mut context = SaveModuleDetailsByNameContext {
             name,
@@ -175,6 +184,7 @@ impl ModuleMap {
     }
 
     /// Create a new [`ModuleMap`] from a list of names
+    #[cfg(not(feature = "nostd"))]
     pub fn new_from_names(gum: &Gum, names: &[&str]) -> Self {
         Self::new_with_filter(gum, &mut |details: ModuleDetails| {
             for name in names {

--- a/frida-gum/src/range_details.rs
+++ b/frida-gum/src/range_details.rs
@@ -14,6 +14,9 @@ use frida_gum_sys as gum_sys;
 use std::ffi::{c_void, CStr};
 use std::marker::PhantomData;
 
+#[cfg(feature = "nostd")]
+use std::prelude::v1::*;
+
 use crate::MemoryRange;
 
 /// The memory protection of an unassociated page.

--- a/frida-gum/src/stalker.rs
+++ b/frida-gum/src/stalker.rs
@@ -42,7 +42,12 @@
 
 use frida_gum_sys as gum_sys;
 use std::marker::PhantomData;
+
+#[cfg(not(feature = "nostd"))]
 use std::os::raw::c_void;
+
+#[cfg(feature = "nostd")]
+use core::ffi::c_void;
 
 use crate::{Gum, MemoryRange, NativePointer};
 

--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -7,7 +7,12 @@
 use crate::{instruction_writer::TargetInstructionWriter, CpuContext, Gum};
 use capstone::Insn;
 use std::marker::PhantomData;
+
+#[cfg(not(feature = "nostd"))]
 use std::os::raw::c_void;
+
+#[cfg(feature = "nostd")]
+use {core::ffi::c_void, std::prelude::v1::*};
 
 pub struct StalkerIterator<'a> {
     iterator: *mut frida_gum_sys::GumStalkerIterator,


### PR DESCRIPTION
Changes to support building `frida-rust` as `no_std`. A couple of APIs are excluded from the `module_map` when built with the `nostd` feature, because of their dependency on `sdt::path::Path` which I couldn't find a `no_std` replacement for. But it should affect the majority of use cases.