### PR TITLE
Fix unsound Transformer::from_callback API

### DIFF
--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -174,7 +174,7 @@ pub struct Transformer<'a> {
 impl<'a> Transformer<'a> {
     pub fn from_callback<'b>(
         _gum: &'b Gum,
-        callback: impl FnMut(StalkerIterator, StalkerOutput),
+        callback: impl FnMut(StalkerIterator, StalkerOutput) + 'a,
     ) -> Transformer<'a>
     where
         'b: 'a,


### PR DESCRIPTION
This makes sure that the callback passed to the `Transformer` outlives the `Transformer` object itself. Previously, the implicit bound was only for the lifetime of the init call, and thus allowed creating callback closures that use dangling captured references.

Note that this breaks the API interface. Should I include a version bump to v`0.13.0`?

Fixes #102.