### PR TITLE
Added get_device_by_id to the device_manager and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/gum/linux_no_std",
     "examples/gum/memory_access_monitor",
     "examples/core/hello",
+    "examples/core/usb_device",
     "examples/core/console_log",
 ]
 # We miss our linux_no_std example from the default members since `cargo check`
@@ -33,5 +34,6 @@ default-members = [
     "examples/gum/fast_interceptor",
     "examples/gum/memory_access_monitor",
     "examples/core/hello",
+    "examples/core/usb_device",
     "examples/core/console_log",
 ]

--- a/examples/core/usb_device/Cargo.toml
+++ b/examples/core/usb_device/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "usb_device"
+version = "0.1.0"
+authors = ["Andras Marczell <andras@chaosrepeat.com>"]
+edition = "2018"
+license = "wxWindows"
+publish = false
+
+[dependencies]
+frida = { path = "../../../frida" }
+frida-sys = { path = "../../../frida-sys" }
+lazy_static = "1.4"

--- a/examples/core/usb_device/src/main.rs
+++ b/examples/core/usb_device/src/main.rs
@@ -7,7 +7,11 @@ fn main() {
     // get the first usb device (assuming there is one attached)
     let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
     assert_eq!(device.get_type(), DeviceType::USB);
-    println!("found {} with type: {}", device.get_name(), device.get_type());
+    println!(
+        "found {} with type: {}",
+        device.get_name(),
+        device.get_type()
+    );
 
     // get the device id and use it to obtain a the device by the id
     let device_id = device.get_id();

--- a/examples/core/usb_device/src/main.rs
+++ b/examples/core/usb_device/src/main.rs
@@ -1,0 +1,17 @@
+use frida::DeviceType;
+
+fn main() {
+    let frida = unsafe { frida::Frida::obtain() };
+    let device_manager = frida::DeviceManager::obtain(&frida);
+
+    // get the first usb device (assuming there is one attached)
+    let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    assert_eq!(device.get_type(), DeviceType::USB);
+    println!("found {} with type: {}", device.get_name(), device.get_type());
+
+    // get the device id and use it to obtain a the device by the id
+    let device_id = device.get_id();
+    let device = device_manager.get_device_by_id(device_id).unwrap();
+    assert_eq!(device.get_id(), device_id);
+    println!("found {} with id: {}", device.get_name(), device.get_id());
+}

--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -5,6 +5,7 @@
  */
 
 use frida_sys::_FridaDeviceManager;
+use std::ffi::CString;
 use std::marker::PhantomData;
 
 use crate::device::Device;
@@ -71,6 +72,39 @@ impl<'a> DeviceManager<'a> {
             frida_sys::frida_device_manager_get_device_by_type_sync(
                 self.manager_ptr,
                 r#type.into(),
+                0,
+                std::ptr::null_mut(),
+                &mut error,
+            )
+        };
+
+        if !error.is_null() {
+            return Err(Error::DeviceLookupFailed);
+        }
+
+        return Ok(Device::from_raw(device_ptr));
+    }
+
+    /// Returns the device with the specified id.
+    ///
+    /// # Example
+    /// ```
+    ///
+    /// let frida = unsafe { frida::Frida::obtain() };
+    /// let device_manager = frida::DeviceManager::obtain(&frida);
+    ///
+    /// let id = "<some id>";
+    /// let device = device_manager.get_device_by_id(id).unwrap();
+    /// assert_eq!(device.get_id(), id);
+    /// ```
+    pub fn get_device_by_id(&'a self, device_id: &str) -> Result<Device<'a>> {
+        let mut error: *mut frida_sys::GError = std::ptr::null_mut();
+        let cstring = CString::new(device_id).unwrap();
+
+        let device_ptr = unsafe {
+            frida_sys::frida_device_manager_get_device_by_id_sync(
+                self.manager_ptr,
+                cstring.as_ptr() as *const i8,
                 0,
                 std::ptr::null_mut(),
                 &mut error,

--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -88,7 +88,6 @@ impl<'a> DeviceManager<'a> {
     /// Returns the device with the specified id.
     ///
     /// # Example
-    /// ```
     ///
     /// let frida = unsafe { frida::Frida::obtain() };
     /// let device_manager = frida::DeviceManager::obtain(&frida);
@@ -96,7 +95,7 @@ impl<'a> DeviceManager<'a> {
     /// let id = "<some id>";
     /// let device = device_manager.get_device_by_id(id).unwrap();
     /// assert_eq!(device.get_id(), id);
-    /// ```
+    ///
     pub fn get_device_by_id(&'a self, device_id: &str) -> Result<Device<'a>> {
         let mut error: *mut frida_sys::GError = std::ptr::null_mut();
         let cstring = CString::new(device_id).unwrap();

--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -103,7 +103,7 @@ impl<'a> DeviceManager<'a> {
         let device_ptr = unsafe {
             frida_sys::frida_device_manager_get_device_by_id_sync(
                 self.manager_ptr,
-                cstring.as_ptr() as *const i8,
+                cstring.as_ptr(),
                 0,
                 std::ptr::null_mut(),
                 &mut error,


### PR DESCRIPTION
Added a convenience method to get a device by its identifier. This is most useful if you have multiple USB or network devices attached and want to work with a specific one without having to enumerate all and find the one by id. 

Created a simple example that demonstrates the usage of the `get_device_by_type` and `get_device_by_id` methods.