### PR TITLE
fix: compilation on nightly

### DIFF
--- a/frida-gum/src/instruction_writer/aarch64/writer.rs
+++ b/frida-gum/src/instruction_writer/aarch64/writer.rs
@@ -7,7 +7,11 @@ use {
     gum_sys::GumArgument,
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::vec::Vec;
 
 /// The Aarch64 instruction writer.

--- a/frida-gum/src/instruction_writer/x86_64/writer.rs
+++ b/frida-gum/src/instruction_writer/x86_64/writer.rs
@@ -5,7 +5,11 @@ use {
     gum_sys::{gssize, GumArgument, GumBranchHint},
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::vec::Vec;
 
 /// The x86/x86_64 instruction writer.

--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -58,7 +58,11 @@
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::missing_safety_doc)]
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 extern crate alloc;
 
 extern crate num;
@@ -71,7 +75,11 @@ use core::{
     fmt::{Debug, Display, Formatter, LowerHex, UpperHex},
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::string::String;
 
 pub mod stalker;

--- a/frida-gum/src/memory_range.rs
+++ b/frida-gum/src/memory_range.rs
@@ -11,7 +11,11 @@ use core::{
     ops::Range,
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::vec::Vec;
 
 pub struct MatchPattern {

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -21,7 +21,11 @@ use {
     frida_gum_sys::{gboolean, gpointer, GumExportDetails, GumModuleDetails, GumSymbolDetails},
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 extern "C" fn enumerate_ranges_callout(

--- a/frida-gum/src/module_map.rs
+++ b/frida-gum/src/module_map.rs
@@ -19,7 +19,11 @@ use {
     frida_gum_sys as gum_sys,
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::{
     boxed::Box,
     string::{String, ToString},

--- a/frida-gum/src/range_details.rs
+++ b/frida-gum/src/range_details.rs
@@ -13,7 +13,6 @@
 extern crate alloc;
 use {
     crate::MemoryRange,
-    alloc::string::String,
     core::{
         ffi::{c_void, CStr},
         marker::PhantomData,
@@ -21,8 +20,12 @@ use {
     frida_gum_sys as gum_sys,
 };
 
-#[cfg(not(feature = "module-names"))]
-use alloc::boxed::Box;
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
+use alloc::{boxed::Box, string::String};
 
 /// The memory protection of an unassociated page.
 #[derive(Clone, FromPrimitive)]

--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -10,7 +10,11 @@ use {
     core::{ffi::c_void, marker::PhantomData},
 };
 
-#[cfg(not(feature = "module-names"))]
+#[cfg(not(any(
+    feature = "module-names",
+    feature = "backtrace",
+    feature = "memory-access-monitor"
+)))]
 use alloc::boxed::Box;
 
 pub struct StalkerIterator<'a> {

--- a/frida/src/process.rs
+++ b/frida/src/process.rs
@@ -5,7 +5,6 @@
  */
 
 use frida_sys::{FridaSpawnOptions, _FridaProcess};
-use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
It does not compile on nightly (`1.79.0-nightly (805813650 2024-03-31)` to be exact) due to the `#![deny(warnings)]` attribute and redundant imports becoming a warning. Thanks!