### PR TITLE
Fix the arm download name

### DIFF
--- a/frida-build/src/lib.rs
+++ b/frida-build/src/lib.rs
@@ -28,7 +28,7 @@ fn download_and_use_devkit_internal(
     if target_arch == "aarch64" {
         target_arch = "arm64".to_string();
     } else if target_arch == "arm" {
-        target_arch = "armhf".to_string();
+        target_arch = "arm".to_string();
     } else if target_arch == "i686" {
         target_arch = "x86".to_string();
     }


### PR DESCRIPTION
On armhf target `frida-build` tries to download the package with suffix `armhf` which doesn't exist. It should be `arm` instead