### PR TITLE
fixed docs example for device_manager.get_device_by_id

### DIFF
--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -111,12 +111,14 @@ impl<'a> DeviceManager<'a> {
     ///
     /// # Example
     ///
-    /// let frida = unsafe { frida::Frida::obtain() };
-    /// let device_manager = frida::DeviceManager::obtain(&frida);
-    ///
+    /// ```no_run
+    /// # let frida = unsafe { frida::Frida::obtain() };
+    /// # let device_manager = frida::DeviceManager::obtain(&frida);
+    /// #
     /// let id = "<some id>";
     /// let device = device_manager.get_device_by_id(id).unwrap();
-    /// assert_eq!(device.get_id(), id);
+    /// # assert_eq!(device.get_id(), id);
+    /// ```
     ///
     pub fn get_device_by_id(&'a self, device_id: &str) -> Result<Device<'a>> {
         let mut error: *mut frida_sys::GError = std::ptr::null_mut();


### PR DESCRIPTION
Backticks were missing, so `<some id>` was interpreted as invalid HTML tag, leading to docs not building.