### PR TITLE
list_exports func added and initial RPC code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/core/hello",
     "examples/core/usb_device",
     "examples/core/console_log",
+    "examples/core/list_exports",
 ]
 # We miss our linux_no_std example from the default members since `cargo check`
 # and `cargo test` both attempt to link the `std` library into it in error.

--- a/examples/core/console_log/src/main.rs
+++ b/examples/core/console_log/src/main.rs
@@ -27,11 +27,11 @@ fn main() {
             let mut script_option = ScriptOption::new()
                 .set_name("example")
                 .set_runtime(ScriptRuntime::QJS);
-            let script = session
+            let mut script = session
                 .create_script("console.log('Log test');", &mut script_option)
                 .unwrap();
 
-            script.handle_message(&mut Handler).unwrap();
+            script.handle_message(Handler).unwrap();
 
             script.load().unwrap();
             println!("[*] Script loaded");
@@ -48,7 +48,7 @@ fn main() {
 struct Handler;
 
 impl ScriptHandler for Handler {
-    fn on_message(&mut self, message: &str) {
-        println!("{message}");
+    fn on_message(&mut self, message: &frida::Message) {
+        println!("{:?}", message);
     }
 }

--- a/examples/core/list_exports/Cargo.toml
+++ b/examples/core/list_exports/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "list_exports"
+version = "0.1.0"
+edition = "2021"
+authors = ["Ricardo J Marques Montilla / Xoffio"]
+
+[dependencies]
+frida = { path = "../../../frida" }
+frida-sys = { path = "../../../frida-sys" }
+lazy_static = "1.5.0"

--- a/examples/core/list_exports/README.md
+++ b/examples/core/list_exports/README.md
@@ -4,12 +4,11 @@ Once ran you should expect an output similar to the next one:
 ```
 [*] Frida version: 16.4.8
 [*] Device name: Local System
-[*] Attached to PID 1124009
+[*] Attached to PID 7581
 - Log(MessageLog { level: Info, payload: "Logging message from JS" })
 - Log(MessageLog { level: Warning, payload: "Warning message from JS" })
 - Log(MessageLog { level: Debug, payload: "Debug message from JS" })
 - Log(MessageLog { level: Error, payload: "Error message from JS" })
-- Error(MessageError { description: "ReferenceError: 'sdfsa' is not defined", stack: "ReferenceError: 'sdfsa' is not defined\n    at <eval> (/script1.js:18)", file_name: "/script1.js", line_number: 18, column_number: 1 })
 [*] Script loaded.
 Some(["increment", "getvalue"])
 Some(["increment", "getvalue"])

--- a/examples/core/list_exports/README.md
+++ b/examples/core/list_exports/README.md
@@ -4,15 +4,14 @@ Once ran you should expect an output similar to the next one:
 ```
 [*] Frida version: 16.4.8
 [*] Device name: Local System
-[*] Attached to PID 7581
 - Log(MessageLog { level: Info, payload: "Logging message from JS" })
 - Log(MessageLog { level: Warning, payload: "Warning message from JS" })
 - Log(MessageLog { level: Debug, payload: "Debug message from JS" })
 - Log(MessageLog { level: Error, payload: "Error message from JS" })
 [*] Script loaded.
-Some(["increment", "getvalue"])
-Some(["increment", "getvalue"])
-Some(["increment", "getvalue"])
+["increment", "getvalue"]
+["increment", "getvalue"]
+["increment", "getvalue"]
 [*] Script unloaded
 [*] Session detached
 Exiting...

--- a/examples/core/list_exports/README.md
+++ b/examples/core/list_exports/README.md
@@ -1,0 +1,20 @@
+Example to showing how to use `script.list_exports()`.
+Once ran you should expect an output similar to the next one:
+
+```
+[*] Frida version: 16.4.8
+[*] Device name: Local System
+[*] Attached to PID 1124009
+- Log(MessageLog { level: Info, payload: "Logging message from JS" })
+- Log(MessageLog { level: Warning, payload: "Warning message from JS" })
+- Log(MessageLog { level: Debug, payload: "Debug message from JS" })
+- Log(MessageLog { level: Error, payload: "Error message from JS" })
+- Error(MessageError { description: "ReferenceError: 'sdfsa' is not defined", stack: "ReferenceError: 'sdfsa' is not defined\n    at <eval> (/script1.js:18)", file_name: "/script1.js", line_number: 18, column_number: 1 })
+[*] Script loaded.
+Some(["increment", "getvalue"])
+Some(["increment", "getvalue"])
+Some(["increment", "getvalue"])
+[*] Script unloaded
+[*] Session detached
+Exiting...
+```

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -1,0 +1,87 @@
+use frida::{Frida, Message};
+use lazy_static::lazy_static;
+use std::{thread, time::Duration};
+
+lazy_static! {
+    static ref FRIDA: Frida = unsafe { Frida::obtain() };
+}
+
+fn main() {
+    let pid = 1134009;
+    let device_manager = frida::DeviceManager::obtain(&FRIDA);
+    let local_device = device_manager.get_device_by_type(frida::DeviceType::Local);
+
+    if let Ok(device) = local_device {
+        println!("[*] Frida version: {}", frida::Frida::version());
+        println!("[*] Device name: {}", device.get_name());
+
+        // Attach to the program
+        let session = device.attach(pid).unwrap();
+
+        if session.is_detached() {
+            println!("Session is detached");
+            return;
+        }
+
+        println!("[*] Attached to PID {}", pid);
+
+        let script_source = r#"
+            var globalVar = 0;
+            console.log("Logging message from JS");
+            console.warn("Warning message from JS");
+            console.debug("Debug message from JS");
+            console.error("Error message from JS");
+
+            rpc.exports = {
+                increment: function() {
+                    globalVar += 1;
+                    return globalVar;
+                },
+                getvalue: function() {
+                    return globalVar;
+                }
+            };
+
+            ;sdfsa // <- Intentional error here
+        "#;
+        let mut script_option = frida::ScriptOption::default();
+        let mut script = match session.create_script(script_source, &mut script_option) {
+            Ok(s) => s,
+            Err(err) => {
+                println!("{}", err);
+                return;
+            }
+        };
+
+        let msg_handler = script.handle_message(Handler);
+        if let Err(err) = msg_handler {
+            panic!("{:?}", err);
+        }
+
+        script.load().unwrap();
+        println!("[*] Script loaded.");
+
+        println!("{:?}", script.list_exports().unwrap());
+
+        for _ in 0..2 {
+            thread::sleep(Duration::from_secs(1));
+            println!("{:?}", script.list_exports().unwrap());
+        }
+
+        script.unload().unwrap();
+        println!("[*] Script unloaded");
+
+        session.detach().unwrap();
+        println!("[*] Session detached");
+    }
+
+    println!("Exiting...");
+}
+
+struct Handler;
+
+impl frida::ScriptHandler for Handler {
+    fn on_message(&mut self, message: &Message) {
+        println!("- {:?}", message);
+    }
+}

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -7,36 +7,20 @@ lazy_static! {
 }
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-
-    if args.len() < 2 {
-        println!("Usage: {} <PID>", args[0]);
-        return;
-    }
-
     let device_manager = frida::DeviceManager::obtain(&FRIDA);
-    let local_device = device_manager.get_device_by_type(frida::DeviceType::Local);
-    let pid: u32 = args[1].parse().unwrap();
+    let local_device = device_manager.get_local_device();
 
     if let Ok(device) = local_device {
         println!("[*] Frida version: {}", frida::Frida::version());
         println!("[*] Device name: {}", device.get_name());
 
         // Attach to the program
-        let session = match device.attach(pid) {
-            Ok(s) => s,
-            Err(_) => {
-                println!("Error attaching to process {}", pid);
-                return;
-            }
-        };
+        let session = device.attach(0).unwrap();
 
         if session.is_detached() {
             println!("Session is detached");
             return;
         }
-
-        println!("[*] Attached to PID {}", pid);
 
         let script_source = r#"
             var globalVar = 0;

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -1,6 +1,5 @@
 use frida::{Frida, Message};
 use lazy_static::lazy_static;
-use std::io::{self, Write};
 use std::{thread, time::Duration};
 
 lazy_static! {
@@ -8,21 +7,16 @@ lazy_static! {
 }
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: {} <PID>", args[0]);
+        return;
+    }
+
     let device_manager = frida::DeviceManager::obtain(&FRIDA);
     let local_device = device_manager.get_device_by_type(frida::DeviceType::Local);
-
-    print!("Enter pid: ",);
-    io::stdout().flush().expect("Failed to flush stdout");
-
-    let mut pid_input = String::new();
-    io::stdin()
-        .read_line(&mut pid_input)
-        .expect("Failed to read pid");
-
-    let pid = pid_input
-        .trim()
-        .parse()
-        .expect("Please enter a valid number");
+    let pid: u32 = args[1].parse().unwrap();
 
     if let Ok(device) = local_device {
         println!("[*] Frida version: {}", frida::Frida::version());
@@ -60,8 +54,6 @@ fn main() {
                     return globalVar;
                 }
             };
-
-            ;sdfsa // <- Intentional error here
         "#;
         let mut script_option = frida::ScriptOption::default();
         let mut script = match session.create_script(script_source, &mut script_option) {

--- a/frida-gum/src/interceptor.rs
+++ b/frida-gum/src/interceptor.rs
@@ -30,10 +30,7 @@ impl<'a> Interceptor<'a> {
     /// Obtain an Interceptor handle, ensuring that the runtime is properly initialized. This may
     /// be called as many times as needed, and results in a no-op if the Interceptor is
     /// already initialized.
-    pub fn obtain<'b>(_gum: &'b Gum) -> Interceptor
-    where
-        'b: 'a,
-    {
+    pub fn obtain<'b: 'a>(_gum: &'b Gum) -> Interceptor<'b> {
         Interceptor {
             interceptor: unsafe { gum_sys::gum_interceptor_obtain() },
             phantom: PhantomData,

--- a/frida-gum/src/stalker.rs
+++ b/frida-gum/src/stalker.rs
@@ -104,10 +104,7 @@ impl<'a> Stalker<'a> {
     /// This call has the overhead of checking if the Stalker is
     /// available on the current platform, as creating a Stalker on an
     /// unsupported platform results in unwanted behaviour.
-    pub fn new<'b>(gum: &'b Gum) -> Stalker
-    where
-        'b: 'a,
-    {
+    pub fn new<'b: 'a>(gum: &'b Gum) -> Stalker<'b> {
         assert!(Self::is_supported(gum));
 
         Stalker {

--- a/frida/Cargo.toml
+++ b/frida/Cargo.toml
@@ -11,8 +11,10 @@ description.workspace = true
 auto-download = ["frida-sys/auto-download"]
 
 [dependencies]
-frida-sys = { path = "../frida-sys" , version = "0.13.7"}
+frida-sys = { path = "../frida-sys", version = "0.13.7" }
 thiserror = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.127"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/frida/src/device.rs
+++ b/frida/src/device.rs
@@ -103,7 +103,7 @@ impl<'a> Device<'a> {
         let mut key = std::ptr::null_mut();
         let mut val = std::ptr::null_mut();
         while (unsafe { frida_sys::g_hash_table_iter_next(&mut iter, &mut key, &mut val) }
-            != frida_sys::FALSE as _)
+            != frida_sys::FALSE as i32)
         {
             let key = unsafe { CStr::from_ptr(key as _) };
             let val = unsafe { Variant::from_ptr(val as _) };

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -246,7 +246,7 @@ impl<'a> Script<'a> {
     }
 
     /// List all the exported attributes from the script's rpc
-    pub fn list_exports(&mut self) -> Result<Option<Vec<String>>> {
+    pub fn list_exports(&mut self) -> Result<Vec<String>> {
         let json_req = {
             let name = "frida:rpc".into();
             let id = self.inc_id().into();
@@ -263,7 +263,7 @@ impl<'a> Script<'a> {
         let (_, rx) = &self.callback_handler.channel;
         let rpc_result = rx.recv().unwrap();
 
-        let func_list: Option<Vec<String>> = match rpc_result {
+        let func_list: Vec<String> = match rpc_result {
             Message::Send(r) => {
                 let tmp_list: Vec<String> = r
                     .payload
@@ -274,13 +274,9 @@ impl<'a> Script<'a> {
                     .map(|i| i.as_str().unwrap_or("").to_string())
                     .collect();
 
-                if !tmp_list.is_empty() {
-                    Some(tmp_list)
-                } else {
-                    None
-                }
+                tmp_list
             }
-            _ => None,
+            _ => Vec::new(),
         };
 
         Ok(func_list)

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -195,7 +195,7 @@ impl<'a> Script<'a> {
     ///
     /// impl ScriptHandler for Handler {
     ///     fn on_message(&mut self, message: &frida::Message) {
-    ///         println!("{message}");
+    ///         println!("{:?}", message);
     ///     }
     /// }
     /// ```

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -23,13 +23,10 @@ use crate::{Error, Result};
 pub enum Message {
     /// Message of type "send"
     Send(MessageSend),
-
     /// Message of type "log"
     Log(MessageLog),
-
     /// Message of type "error"
     Error(MessageError),
-
     /// Any other type of message.
     Other(Value),
 }
@@ -57,16 +54,12 @@ pub struct MessageLog {
 pub struct MessageError {
     /// Error description.
     pub description: String,
-
     /// Stack trace string.
     pub stack: String,
-
     /// Script file name that failed.
     pub file_name: String,
-
     /// Line number with the error.
     pub line_number: usize,
-
     /// Column number with the error.
     pub column_number: usize,
 }

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -5,7 +5,11 @@
  */
 
 use frida_sys::{FridaScriptOptions, _FridaScript, g_bytes_new, g_bytes_unref};
+use serde::Deserialize;
+use serde_json::Value;
+use std::cell::Cell;
 use std::marker::PhantomData;
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{
     ffi::{c_char, c_void, CStr, CString},
     ptr::null_mut,
@@ -13,31 +17,146 @@ use std::{
 
 use crate::{Error, Result};
 
+/// Represents a Frida message
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
+pub enum Message {
+    /// Message of type "send"
+    Send(MessageSend),
+
+    /// Message of type "log"
+    Log(MessageLog),
+
+    /// Message of type "error"
+    Error(MessageError),
+
+    /// Any other type of message.
+    Other(Value),
+}
+
+/// Send Message.
+#[derive(Deserialize, Debug)]
+pub struct MessageSend {
+    /// Payload of a Send Message.
+    pub payload: SendPayload,
+}
+
+/// Log Message.
+#[derive(Deserialize, Debug)]
+pub struct MessageLog {
+    /// Log Level.
+    pub level: MessageLogLevel,
+    /// Payload of a Message Log.
+    pub payload: String,
+}
+
+/// Error message.
+/// This message is sent when a JavaScript runtime error occurs, such as a misspelled word.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageError {
+    /// Error description.
+    pub description: String,
+
+    /// Stack trace string.
+    pub stack: String,
+
+    /// Script file name that failed.
+    pub file_name: String,
+
+    /// Line number with the error.
+    pub line_number: usize,
+
+    /// Column number with the error.
+    pub column_number: usize,
+}
+
+/// Represents a Message Log Level Types.
+/// Used by `MessageLog._level`
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageLogLevel {
+    /// Indicates an informal message.
+    Info,
+    /// Represents a debugging message.
+    Debug,
+    /// Signifies a warning message.
+    Warning,
+    /// Represents an error message.
+    Error,
+}
+
+/// Represents a Message Log Level Types.
+/// Used by `MessageLog._level`
+#[derive(Deserialize, Debug)]
+pub struct SendPayload {
+    /// Send message type
+    pub r#type: String,
+    /// Send message ID
+    pub id: usize,
+    /// Send message result.
+    pub result: String,
+    /// Send message returns.
+    pub returns: Value,
+}
+
 unsafe extern "C" fn call_on_message<I: ScriptHandler>(
     _script_ptr: *mut _FridaScript,
     message: *const i8,
     _data: &frida_sys::_GBytes,
     user_data: *mut c_void,
 ) {
-    let handler: &mut I = &mut *(user_data as *mut I);
+    let c_msg = CStr::from_ptr(message as *const c_char)
+        .to_str()
+        .unwrap_or_default();
 
-    handler.on_message(
-        CStr::from_ptr(message as *const c_char)
-            .to_str()
-            .unwrap_or_default(),
-    );
+    let formated_msg: Message = serde_json::from_str(c_msg).unwrap_or_else(|err| {
+        Message::Other(serde_json::json!({
+            "error": err.to_string(),
+            "data": c_msg
+        }))
+    });
+
+    match formated_msg {
+        Message::Send(msg) => {
+            if msg.payload.r#type == "frida:rpc" {
+                let callback_handler: *mut CallbackHandler = user_data as _;
+                on_message(callback_handler.as_mut().unwrap(), Message::Send(msg));
+            }
+        }
+        Message::Log(msg) => {
+            let handler: &mut I = &mut *(user_data as *mut I);
+            handler.on_message(&Message::Log(msg));
+        }
+        Message::Error(msg) => {
+            let handler: &mut I = &mut *(user_data as *mut I);
+            handler.on_message(&Message::Error(msg));
+        }
+        Message::Other(msg) => {
+            let handler: &mut I = &mut *(user_data as *mut I);
+            handler.on_message(&Message::Other(msg));
+        }
+    }
+}
+
+fn on_message(cb_handler: &mut CallbackHandler, message: Message) {
+    let (tx, _) = &cb_handler.channel;
+    let _ = tx.send(message);
 }
 
 /// Represents a script signal handler.
 pub trait ScriptHandler {
     /// Handler called when a message is shared from JavaScript to Rust.
-    fn on_message(&mut self, message: &str);
+    fn on_message(&mut self, message: &Message);
 }
 
 /// Reprents a Frida script.
 pub struct Script<'a> {
     script_ptr: *mut _FridaScript,
     phantom: PhantomData<&'a _FridaScript>,
+    rpc_id_counter: Cell<usize>,
+    callback_handler: CallbackHandler,
 }
 
 impl<'a> Script<'a> {
@@ -45,6 +164,8 @@ impl<'a> Script<'a> {
         Script {
             script_ptr,
             phantom: PhantomData,
+            rpc_id_counter: Cell::new(0),
+            callback_handler: CallbackHandler::new(),
         }
     }
 
@@ -82,13 +203,14 @@ impl<'a> Script<'a> {
     /// struct Handler;
     ///
     /// impl ScriptHandler for Handler {
-    ///     fn on_message(&mut self, message: &str) {
+    ///     fn on_message(&mut self, message: &frida::Message) {
     ///         println!("{message}");
     ///     }
     /// }
     /// ```
-    pub fn handle_message<I: ScriptHandler>(&self, handler: &mut I) -> Result<()> {
+    pub fn handle_message<I: ScriptHandler + 'static>(&mut self, handler: I) -> Result<()> {
         let message = CString::new("message").map_err(|_| Error::CStringFailed)?;
+        self.callback_handler.add_handler(handler);
         unsafe {
             let callback = Some(std::mem::transmute::<
                 *mut std::ffi::c_void,
@@ -99,7 +221,7 @@ impl<'a> Script<'a> {
                 self.script_ptr as _,
                 message.as_ptr(),
                 callback,
-                handler as *mut _ as *mut c_void,
+                (&self.callback_handler as *const _ as *mut CallbackHandler) as *mut c_void,
                 None,
                 0,
             )
@@ -125,6 +247,52 @@ impl<'a> Script<'a> {
         }
 
         Ok(())
+    }
+
+    fn inc_id(&self) -> usize {
+        let current_id_counter = self.rpc_id_counter.get();
+        self.rpc_id_counter.replace(current_id_counter + 1)
+    }
+
+    /// List all the exported attributes from the script's rpc
+    pub fn list_exports(&self) -> Result<Option<Vec<String>>> {
+        let json_req = {
+            let name = "frida:rpc".into();
+            let id = self.inc_id().into();
+            let rpc_type = "list".into();
+            let rpc_function = Value::Null;
+            let args = Value::Null;
+
+            let rpc_query: [Value; 5] = [name, id, rpc_type, rpc_function, args];
+
+            serde_json::to_string(&rpc_query).unwrap()
+        };
+
+        self.post(&json_req, None).unwrap();
+        let (_, rx) = &self.callback_handler.channel;
+        let rpc_result = rx.recv().unwrap();
+
+        let func_list: Option<Vec<String>> = match rpc_result {
+            Message::Send(r) => {
+                let tmp_list: Vec<String> = r
+                    .payload
+                    .returns
+                    .as_array()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .map(|i| i.as_str().unwrap_or("").to_string())
+                    .collect();
+
+                if !tmp_list.is_empty() {
+                    Some(tmp_list)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        Ok(func_list)
     }
 }
 
@@ -202,5 +370,23 @@ impl Drop for ScriptOption {
                 &mut self.ptr as *mut *mut frida_sys::_FridaScriptOptions as _,
             )
         }
+    }
+}
+
+struct CallbackHandler {
+    channel: (Sender<Message>, Receiver<Message>),
+    script_handler: Option<Box<dyn ScriptHandler>>,
+}
+
+impl CallbackHandler {
+    fn new() -> Self {
+        Self {
+            channel: channel(),
+            script_handler: None,
+        }
+    }
+
+    fn add_handler<I: ScriptHandler + 'static>(&mut self, handler: I) {
+        self.script_handler = Some(Box::from(handler));
     }
 }

--- a/frida/src/variant.rs
+++ b/frida/src/variant.rs
@@ -32,7 +32,7 @@ impl Variant {
                 Self::String(value)
             }
             "b" => {
-                Self::Boolean(frida_sys::g_variant_get_boolean(variant) != frida_sys::FALSE as _)
+                Self::Boolean(frida_sys::g_variant_get_boolean(variant) != frida_sys::FALSE as i32)
             }
             "x" => Self::Int64(frida_sys::g_variant_get_int64(variant)),
             "a{sv}" => Self::Map(sv_array_to_map(variant)),


### PR DESCRIPTION
- Implemented the function `list_exports`. Included an example demonstrating how to use it.
- Updated the example `console_log` to align with the recent changes made to the `on_message` function.
- Adjusted types in `device.rs` and `variant.rs`: After adding serde to cargo, I encountered compilation issues with `frida_sys::FALSE`. I set the types to resolve these issues.

Please let me know if you have any notes. Once we get this approved I can move to finalize the RPC calls #105 