### PR TITLE
frida-gum: add std feature

### DIFF
--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -9,13 +9,14 @@ description.workspace = true
 
 [features]
 auto-download = ["frida-gum-sys/auto-download"]
-backtrace = ["libc"]
+backtrace = ["libc", "std"]
 event-sink = ["frida-gum-sys/event-sink"]
 invocation-listener = ["frida-gum-sys/invocation-listener"]
-memory-access-monitor = []
-module-names = []
+memory-access-monitor = ["std"]
+module-names = ["std"]
 stalker-observer = ["frida-gum-sys/stalker-observer"]
 stalker-params = ["frida-gum-sys/stalker-params"]
+std = []
 
 [dependencies]
 cstr_core = { version = "0.2.6", default-features = false, features = ["alloc"] }
@@ -33,4 +34,4 @@ lazy_static = "1"
 maintenance = { status = "experimental" }
 
 [package.metadata.docs.rs]
-features = ["event-sink", "invocation-listener", "stalker-observer", "stalker-params"]
+features = ["event-sink", "invocation-listener", "stalker-observer", "stalker-params", "std"]

--- a/frida-gum/src/lib.rs
+++ b/frida-gum/src/lib.rs
@@ -45,23 +45,12 @@
 //! }
 //! ```
 
-#![cfg_attr(
-    not(any(
-        feature = "module-names",
-        feature = "backtrace",
-        feature = "memory-access-monitor"
-    )),
-    no_std
-)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(warnings)]
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::missing_safety_doc)]
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 extern crate num;
@@ -74,11 +63,7 @@ use core::{
     fmt::{Debug, Display, Formatter, LowerHex, UpperHex},
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 pub mod stalker;

--- a/frida-gum/src/memory_range.rs
+++ b/frida-gum/src/memory_range.rs
@@ -11,11 +11,7 @@ use core::{
     ops::Range,
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub struct MatchPattern {

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -21,11 +21,7 @@ use {
     frida_gum_sys::{gboolean, gpointer, GumExportDetails, GumModuleDetails, GumSymbolDetails},
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 extern "C" fn enumerate_ranges_callout(

--- a/frida-gum/src/module_map.rs
+++ b/frida-gum/src/module_map.rs
@@ -19,11 +19,7 @@ use {
     frida_gum_sys as gum_sys,
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::{
     boxed::Box,
     string::{String, ToString},

--- a/frida-gum/src/range_details.rs
+++ b/frida-gum/src/range_details.rs
@@ -20,11 +20,7 @@ use {
     frida_gum_sys as gum_sys,
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, string::String};
 
 /// The memory protection of an unassociated page.

--- a/frida-gum/src/stalker/transformer.rs
+++ b/frida-gum/src/stalker/transformer.rs
@@ -10,11 +10,7 @@ use {
     core::{ffi::c_void, marker::PhantomData},
 };
 
-#[cfg(not(any(
-    feature = "module-names",
-    feature = "backtrace",
-    feature = "memory-access-monitor"
-)))]
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
 pub struct StalkerIterator<'a> {


### PR DESCRIPTION
The use of an ad-hoc list of features to enable std is weird. It's better to centralize under one std feature that these features enable.

Fixes #154