### PR TITLE
frida-gum: use a singleton gum instance

### DIFF
--- a/frida-gum-sys/src/lib.rs
+++ b/frida-gum-sys/src/lib.rs
@@ -17,7 +17,7 @@ mod bindings {
 pub use bindings::*;
 
 #[cfg(not(any(target_os = "windows", target_os = "android", target_vendor = "apple",)))]
-pub use _frida_g_object_unref as g_object_unref;
+pub use {_frida_g_object_ref as g_object_ref, _frida_g_object_unref as g_object_unref};
 
 /// A single disassembled CPU instruction.
 #[repr(transparent)]

--- a/frida-gum/Cargo.toml
+++ b/frida-gum/Cargo.toml
@@ -28,6 +28,10 @@ num = { version = "0.4.1", default-features = false }
 num-derive = { version = "0.4.2", default-features = false }
 num-traits = { version = "0.2.18", default-features = false }
 paste = { version = "1", default-features = false }
+spin = { version = "0.9.8", default-features = false, features = [
+    "mutex",
+    "spin_mutex",
+] }
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
This makes the Gum APIs sane with regards to calling obtain. If this is liked, I'll send another patch with a similar API for the frida crate. One note is that a spinlock was added to make it easier to implement the drop logic correctly.