### PR TITLE
Fix Aarch64 compilation errors

### DIFF
--- a/frida/src/variant.rs
+++ b/frida/src/variant.rs
@@ -104,7 +104,7 @@ unsafe fn sv_array_to_map(variant: *mut frida_sys::GVariant) -> HashMap<String, 
     frida_sys::g_variant_iter_init(&mut iter, variant);
     let sv = CString::new("{sv}").unwrap();
     while frida_sys::g_variant_iter_loop(&mut iter, sv.as_ptr(), &mut key, &mut value) != 0 {
-        let key = CStr::from_ptr(key).to_string_lossy().to_string();
+        let key = CStr::from_ptr(key.cast()).to_string_lossy().to_string();
         let value = Variant::from_ptr(value);
         ret.insert(key, value);
     }
@@ -124,7 +124,7 @@ unsafe fn asv_array_to_maplist(variant: *mut frida_sys::GVariant) -> Vec<HashMap
     while frida_sys::g_variant_iter_loop(&mut outer, asv.as_ptr(), &mut inner) != 0 {
         let mut map = HashMap::new();
         while frida_sys::g_variant_iter_loop(inner, sv.as_ptr(), &mut key, &mut value) != 0 {
-            let key = CStr::from_ptr(key).to_string_lossy().to_string();
+            let key = CStr::from_ptr(key.cast()).to_string_lossy().to_string();
             let value = Variant::from_ptr(value);
             map.insert(key, value);
         }


### PR DESCRIPTION
When compiling on the Aarch64 platform, I encountered the following error:

```
error[E0308]: mismatched types
   --> /home/ttc/Workspace/frida-rust/frida/src/variant.rs:107:34
    |
107 |         let key = CStr::from_ptr(key).to_string_lossy().to_string();
    |                   -------------- ^^^ expected `*const u8`, found `*const i8`
    |                   |
    |                   arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: associated function defined here
   --> /home/ttc/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ffi/c_str.rs:284:25
    |
284 |     pub const unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a CStr {
    |                         ^^^^^^^^

error[E0308]: mismatched types
   --> /home/ttc/Workspace/frida-rust/frida/src/variant.rs:127:38
    |
127 |             let key = CStr::from_ptr(key).to_string_lossy().to_string();
    |                       -------------- ^^^ expected `*const u8`, found `*const i8`
    |                       |
    |                       arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: associated function defined here
   --> /home/ttc/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ffi/c_str.rs:284:25
    |
284 |     pub const unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a CStr {
    |                         ^^^^^^^^
```

This error does not occur on x64, and this PR fixes the problem.