### PR TITLE
Link with Security & IOKit frameworks in MacOS

### DIFF
--- a/frida-sys/build.rs
+++ b/frida-sys/build.rs
@@ -37,6 +37,8 @@ fn main() {
         println!("cargo:rustc-link-lib=pthread");
         if target_os == "macos" {
             println!("cargo:rustc-link-lib=framework=AppKit");
+            println!("cargo:rustc-link-lib=framework=Security");
+            println!("cargo:rustc-link-lib=framework=IOKit");
         }
     }
 


### PR DESCRIPTION
When trying to compile some examples in macos I get errors like the next one:

```
          Undefined symbols for architecture x86_64:
            "_IOCreatePlugInInterfaceForService", referenced from:
                _darwin_device_from_service in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_claim_interface in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOIteratorNext", referenced from:
                _darwin_init in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_devices_detached in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_devices_attached in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_clear_iterator in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _process_new_device in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_get_interface in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOKitWaitQuiet", referenced from:
                _darwin_hotplug_poll in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IONotificationPortCreate", referenced from:
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IONotificationPortDestroy", referenced from:
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IONotificationPortGetRunLoopSource", referenced from:
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOObjectRelease", referenced from:
                _darwin_init in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_init in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_kernel_driver_active in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_kernel_driver_active in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_devices_detached in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                ...
            "_IOObjectRetain", referenced from:
                _darwin_get_cached_device in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IORegistryEntryCreateCFProperty", referenced from:
                _get_ioregistry_value_number in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_get_cached_device in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IORegistryEntryGetChildEntry", referenced from:
                _darwin_kernel_driver_active in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IORegistryEntryGetParentEntry", referenced from:
                _darwin_get_cached_device in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_get_cached_device in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOServiceAddMatchingNotification", referenced from:
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOServiceAuthorize", referenced from:
                _darwin_detach_kernel_driver in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOServiceGetMatchingService", referenced from:
                _usb_find_interface_matching_location in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOServiceGetMatchingServices", referenced from:
                _darwin_init in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_IOServiceMatching", referenced from:
                _darwin_init in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _darwin_event_thread_main in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
                _usb_find_interface_matching_location in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_SecTaskCopyValueForEntitlement", referenced from:
                _darwin_detach_kernel_driver in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
            "_SecTaskCreateFromSelf", referenced from:
                _darwin_detach_kernel_driver in libfrida-core.a[471](libusb_os_darwin_usb.c.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `list_exports` (bin "list_exports") due to 1 previous error
~/Documents/hexomorph/src-tauri/frida/frida-rust/frida-rust/examples/core/list_exports> 
```

This has something to do with this -> https://github.com/frida/frida/issues/2910
