### PR TITLE
frida-gum: force frida-gum init to use Module (#98)

### DIFF
--- a/examples/gum/debug_symbol/src/main.rs
+++ b/examples/gum/debug_symbol/src/main.rs
@@ -1,15 +1,14 @@
 use frida_gum::DebugSymbol;
 use frida_gum::{Gum, Module};
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref GUM: Gum = unsafe { Gum::obtain() };
-}
+use std::iter::Once;
+use std::sync::OnceLock;
 
 fn main() {
-    lazy_static::initialize(&GUM);
+    static CELL: OnceLock<Gum> = OnceLock::new();
+    let gum = CELL.get_or_init(|| Gum::obtain());
 
-    let symbol = Module::find_export_by_name(None, "mmap").unwrap();
+    let module = Module::from_gum(gum);
+    let symbol = module.find_export_by_name(None, "mmap").unwrap();
     let symbol_details = DebugSymbol::from_address(symbol).unwrap();
     println!(
         "address={:#x?} module_name={:?} symbol_name={:?} file_name={:?} line_number={:?}",

--- a/examples/gum/debug_symbol/src/main.rs
+++ b/examples/gum/debug_symbol/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
 
-    let module = Module::from_gum(gum);
+    let module = Module::obtain(gum);
     let symbol = module.find_export_by_name(None, "mmap").unwrap();
     let symbol_details = DebugSymbol::from_address(symbol).unwrap();
     println!(

--- a/examples/gum/hook_instruction/Cargo.toml
+++ b/examples/gum/hook_instruction/Cargo.toml
@@ -11,5 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 frida-gum = { path = "../../../frida-gum", features = ["invocation-listener"] }
-lazy_static = "1.4"
 ctor = "0.2"

--- a/examples/gum/hook_instruction/src/lib.rs
+++ b/examples/gum/hook_instruction/src/lib.rs
@@ -3,11 +3,7 @@ use frida_gum::{
     interceptor::{Interceptor, InvocationContext, ProbeListener},
     Gum, Module,
 };
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref GUM: Gum = unsafe { Gum::obtain() };
-}
+use std::sync::OnceLock;
 #[derive(Default, Debug)]
 struct OpenProbeListener;
 
@@ -19,8 +15,11 @@ impl ProbeListener for OpenProbeListener {
 
 #[ctor]
 fn init() {
-    let mut interceptor = Interceptor::obtain(&GUM);
-    let open = Module::find_export_by_name(None, "open").unwrap();
+    static CELL: OnceLock<Gum> = OnceLock::new();
+    let gum = CELL.get_or_init(|| Gum::obtain());
+    let mut interceptor = Interceptor::obtain(gum);
+    let module = Module::from_gum(gum);
+    let open = module.find_export_by_name(None, "open").unwrap();
     let mut listener = OpenProbeListener;
     interceptor.attach_instruction(open, &mut listener).unwrap();
 }

--- a/examples/gum/hook_instruction/src/lib.rs
+++ b/examples/gum/hook_instruction/src/lib.rs
@@ -18,7 +18,7 @@ fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
     let mut interceptor = Interceptor::obtain(gum);
-    let module = Module::from_gum(gum);
+    let module = Module::obtain(gum);
     let open = module.find_export_by_name(None, "open").unwrap();
     let mut listener = OpenProbeListener;
     interceptor.attach_instruction(open, &mut listener).unwrap();

--- a/examples/gum/hook_open/src/lib.rs
+++ b/examples/gum/hook_open/src/lib.rs
@@ -31,7 +31,7 @@ unsafe extern "C" fn open_detour(name: *const c_char, flags: c_int) -> c_int {
 fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
-    let module = Module::from_gum(gum);
+    let module = Module::obtain(gum);
     let mut interceptor = Interceptor::obtain(gum);
     let open = module.find_export_by_name(None, "open").unwrap();
     unsafe {

--- a/examples/gum/open/Cargo.toml
+++ b/examples/gum/open/Cargo.toml
@@ -11,4 +11,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 frida-gum = { path = "../../../frida-gum", features = ["invocation-listener"] }
-lazy_static = "1.4"

--- a/examples/gum/open/src/lib.rs
+++ b/examples/gum/open/src/lib.rs
@@ -30,7 +30,7 @@ extern "C" fn example_agent_main(_user_data: *const c_void, resident: *mut c_int
     let mut interceptor = Interceptor::obtain(gum);
     let mut listener = OpenListener {};
 
-    let module = Module::from_gum(gum);
+    let module = Module::obtain(gum);
     let modules = module.enumerate_modules();
     for module in modules {
         println!(

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -72,7 +72,7 @@ impl Module {
     /// The absolute address of the export. In the event that no such export
     /// could be found, returns NULL.
     pub fn find_export_by_name(
-        self: &Self,
+        &self,
         module_name: Option<&str>,
         symbol_name: &str,
     ) -> Option<NativePointer> {
@@ -104,7 +104,7 @@ impl Module {
     /// The absolute address of the symbol. In the event that no such symbol
     /// could be found, returns NULL.
     pub fn find_symbol_by_name(
-        self: &Self,
+        &self,
         module_name: &str,
         symbol_name: &str,
     ) -> Option<NativePointer> {
@@ -127,7 +127,7 @@ impl Module {
 
     /// Returns the base address of the specified module. In the event that no
     /// such module could be found, returns NULL.
-    pub fn find_base_address(self: &Self, module_name: &str) -> NativePointer {
+    pub fn find_base_address(&self, module_name: &str) -> NativePointer {
         let module_name = CString::new(module_name).unwrap();
 
         unsafe {
@@ -139,7 +139,7 @@ impl Module {
 
     /// Enumerates memory ranges satisfying protection given.
     pub fn enumerate_ranges(
-        self: &Self,
+        &self,
         module_name: &str,
         prot: PageProtection,
         callout: impl FnMut(RangeDetails) -> bool,
@@ -163,7 +163,7 @@ impl Module {
     }
 
     /// Enumerates modules.
-    pub fn enumerate_modules(self: &Self) -> Vec<ModuleDetailsOwned> {
+    pub fn enumerate_modules(&self) -> Vec<ModuleDetailsOwned> {
         let result: Vec<ModuleDetailsOwned> = vec![];
 
         unsafe extern "C" fn callback(
@@ -203,7 +203,7 @@ impl Module {
     }
 
     /// Enumerates exports in module.
-    pub fn enumerate_exports(self: &Self, module_name: &str) -> Vec<ExportDetails> {
+    pub fn enumerate_exports(&self, module_name: &str) -> Vec<ExportDetails> {
         let result: Vec<ExportDetails> = vec![];
 
         unsafe extern "C" fn callback(
@@ -235,7 +235,7 @@ impl Module {
     }
 
     /// Enumerates symbols in module.
-    pub fn enumerate_symbols(self: &Self, module_name: &str) -> Vec<SymbolDetails> {
+    pub fn enumerate_symbols(&self, module_name: &str) -> Vec<SymbolDetails> {
         let result: Vec<SymbolDetails> = vec![];
         unsafe extern "C" fn callback(
             details: *const GumSymbolDetails,

--- a/frida-gum/src/module.rs
+++ b/frida-gum/src/module.rs
@@ -65,7 +65,7 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn from_gum(gum: &'static Gum) -> Module {
+    pub fn obtain(gum: &'static Gum) -> Module {
         Module { _gum: gum }
     }
 


### PR DESCRIPTION
In order to use the underlying C API global init should be called.

We hence force the creation of Gum to use Module::* functions.

We also use OnceLock instead of lazy_static! as discussed in the issue.