### PR TITLE
Core examples - use LazyLock & clean unnecessary crates

### DIFF
--- a/examples/core/console_log/Cargo.toml
+++ b/examples/core/console_log/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-lazy_static = "1.4"

--- a/examples/core/console_log/src/main.rs
+++ b/examples/core/console_log/src/main.rs
@@ -1,9 +1,7 @@
 use frida::{DeviceManager, Frida, ScriptHandler, ScriptOption, ScriptRuntime};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref FRIDA: Frida = unsafe { Frida::obtain() };
-}
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/examples/core/get_processes/Cargo.toml
+++ b/examples/core/get_processes/Cargo.toml
@@ -7,5 +7,3 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }
-lazy_static = "1.5.0"

--- a/examples/core/get_processes/src/main.rs
+++ b/examples/core/get_processes/src/main.rs
@@ -1,9 +1,7 @@
 use frida::Frida;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref FRIDA: Frida = unsafe { Frida::obtain() };
-}
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
 
 fn main() {
     let device_manager = frida::DeviceManager::obtain(&FRIDA);

--- a/examples/core/hello/Cargo.toml
+++ b/examples/core/hello/Cargo.toml
@@ -8,5 +8,3 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }
-lazy_static = "1.4"

--- a/examples/core/hello/src/main.rs
+++ b/examples/core/hello/src/main.rs
@@ -1,11 +1,9 @@
 /* This example is in the public domain */
 
 use frida::Frida;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref FRIDA: Frida = unsafe { Frida::obtain() };
-}
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
 
 fn main() {
     println!("Hello, world!");

--- a/examples/core/inject_lib_blob/Cargo.toml
+++ b/examples/core/inject_lib_blob/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }

--- a/examples/core/inject_lib_file/Cargo.toml
+++ b/examples/core/inject_lib_file/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }

--- a/examples/core/list_exports/Cargo.toml
+++ b/examples/core/list_exports/Cargo.toml
@@ -7,5 +7,3 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }
-lazy_static = "1.5.0"

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -1,10 +1,8 @@
 use frida::{Frida, Message};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use std::{thread, time::Duration};
 
-lazy_static! {
-    static ref FRIDA: Frida = unsafe { Frida::obtain() };
-}
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
 
 fn main() {
     let device_manager = frida::DeviceManager::obtain(&FRIDA);

--- a/examples/core/rpc_execute_function/Cargo.toml
+++ b/examples/core/rpc_execute_function/Cargo.toml
@@ -7,7 +7,5 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }
-lazy_static = "1.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.127"

--- a/examples/core/rpc_execute_function/src/main.rs
+++ b/examples/core/rpc_execute_function/src/main.rs
@@ -1,10 +1,8 @@
 use frida::{Frida, Message};
-use lazy_static::lazy_static;
 use serde_json::json;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref FRIDA: Frida = unsafe { Frida::obtain() };
-}
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
 
 fn main() {
     let device_manager = frida::DeviceManager::obtain(&FRIDA);

--- a/examples/core/usb_device/Cargo.toml
+++ b/examples/core/usb_device/Cargo.toml
@@ -8,5 +8,3 @@ publish = false
 
 [dependencies]
 frida = { path = "../../../frida" }
-frida-sys = { path = "../../../frida-sys" }
-lazy_static = "1.4"


### PR DESCRIPTION
- Use of LazyLock instead of lazy_static
- Clean up unnecessary frida-sys & lazy_static crates
- Examples ran and tested