### PR TITLE
fix linkage for frida-gum script example for macos

### DIFF
--- a/examples/gum/script/build.rs
+++ b/examples/gum/script/build.rs
@@ -1,3 +1,6 @@
 fn main() {
     println!("cargo:rustc-link-arg=-rdynamic");
+    
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=dylib=c++");
 }

--- a/examples/gum/script/build.rs
+++ b/examples/gum/script/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!("cargo:rustc-link-arg=-rdynamic");
-    
+
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-lib=dylib=c++");
 }

--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -242,4 +242,7 @@ fn main() {
 
     #[cfg(all(feature = "js", target_os = "macos"))]
     println!("cargo:rustc-link-lib=dylib=c++");
+
+    #[cfg(all(feature = "js", target_os = "macos"))]
+    println!("cargo:rustc-link-lib=resolv");
 }


### PR DESCRIPTION
fix error when building `examples/gum/script`:

```
= note: Undefined symbols for architecture arm64:
            "_res_9_dn_expand", referenced from:
                _OUTLINED_FUNCTION_16 in libfrida_gum_sys-75fd3f9127f13c0d.rlib[1357](gthreadedresolver.c.o)
            "_res_9_ndestroy", referenced from:
                _do_lookup_records in libfrida_gum_sys-75fd3f9127f13c0d.rlib[1357](gthreadedresolver.c.o)
            "_res_9_ninit", referenced from:
                _do_lookup_records in libfrida_gum_sys-75fd3f9127f13c0d.rlib[1357](gthreadedresolver.c.o)
            "_res_9_nquery", referenced from:
                _do_lookup_records in libfrida_gum_sys-75fd3f9127f13c0d.rlib[1357](gthreadedresolver.c.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```