### PR TITLE
Fix linking on Apple OSs

### DIFF
--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -242,4 +242,7 @@ fn main() {
 
     #[cfg(all(feature = "js", target_os = "macos"))]
     println!("cargo:rustc-link-lib=dylib=c++");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=dylib=resolv");
 }

--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -243,6 +243,6 @@ fn main() {
     #[cfg(all(feature = "js", target_os = "macos"))]
     println!("cargo:rustc-link-lib=dylib=c++");
 
-    #[cfg(target_os = "macos")]
+    #[cfg(target_vendor = "apple")]
     println!("cargo:rustc-link-lib=dylib=resolv");
 }


### PR DESCRIPTION
There is currently a problem on Apple devices where, during linking, it will complain about undefined symbols:

```
Undefined symbols for architecture arm64:
            "_res_9_dn_expand", referenced from:
                _OUTLINED_FUNCTION_16 in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_ndestroy", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_ninit", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
            "_res_9_nquery", referenced from:
                _do_lookup_records in libfrida_gum_sys-a07f5e3f0fd74186.rlib(gthreadedresolver.c.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The following PR fixes this by linking the resolv library on apple devices. 