### PR TITLE
Implement support for accessing binary data sent alongside messages

### DIFF
--- a/examples/core/console_log/src/main.rs
+++ b/examples/core/console_log/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 struct Handler;
 
 impl ScriptHandler for Handler {
-    fn on_message(&mut self, message: &frida::Message) {
+    fn on_message(&mut self, message: &frida::Message, _data: Option<Vec<u8>>) {
         println!("{:?}", message);
     }
 }

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
 struct Handler;
 
 impl frida::ScriptHandler for Handler {
-    fn on_message(&mut self, message: &Message) {
+    fn on_message(&mut self, message: &Message, _data: Option<Vec<u8>>) {
         println!("- {:?}", message);
     }
 }

--- a/examples/core/rpc_execute_function/src/main.rs
+++ b/examples/core/rpc_execute_function/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
 struct Handler;
 
 impl frida::ScriptHandler for Handler {
-    fn on_message(&mut self, message: &Message) {
+    fn on_message(&mut self, message: &Message, _data: Option<Vec<u8>>) {
         println!("- {:?}", message);
     }
 }

--- a/frida-sys/src/lib.rs
+++ b/frida-sys/src/lib.rs
@@ -18,8 +18,8 @@ pub use bindings::*;
 
 #[cfg(not(any(target_vendor = "apple", target_os = "windows")))]
 pub use crate::{
-    _frida_g_bytes_new as g_bytes_new, _frida_g_bytes_unref as g_bytes_unref,
-    _frida_g_clear_object as g_clear_object,
+    _frida_g_bytes_get_data as g_bytes_get_data, _frida_g_bytes_new as g_bytes_new,
+    _frida_g_bytes_unref as g_bytes_unref, _frida_g_clear_object as g_clear_object,
     _frida_g_hash_table_iter_init as g_hash_table_iter_init,
     _frida_g_hash_table_iter_next as g_hash_table_iter_next,
     _frida_g_hash_table_size as g_hash_table_size, _frida_g_idle_source_new as g_idle_source_new,


### PR DESCRIPTION
Just a bit of plumbing that was missing.

Not sure whether the copy to a vector is strictly needed, it might be possible to get away without but I didn't want to risk it.