### PR TITLE
Device: enumerate apps

### DIFF
--- a/examples/core/get_apps/Cargo.toml
+++ b/examples/core/get_apps/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "get_apps"
+version = "0.1.0"
+edition = "2021"
+authors = ["Zhi Zhou"]
+publish = false
+
+[dependencies]
+frida = { path = "../../../frida" }

--- a/examples/core/get_apps/src/main.rs
+++ b/examples/core/get_apps/src/main.rs
@@ -3,7 +3,7 @@ use frida::{Scope, DeviceType};
 fn main() {
     let frida = unsafe { frida::Frida::obtain() };
     let device_manager = frida::DeviceManager::obtain(&frida);
-    let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    let device = device_manager.get_usb_device().unwrap();
     assert_eq!(device.get_type(), DeviceType::USB);
     let apps = device.enumerate_applications(None, None);
 

--- a/examples/core/get_apps/src/main.rs
+++ b/examples/core/get_apps/src/main.rs
@@ -1,0 +1,26 @@
+use frida::{Scope, DeviceType};
+
+fn main() {
+    let frida = unsafe { frida::Frida::obtain() };
+    let device_manager = frida::DeviceManager::obtain(&frida);
+    let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    assert_eq!(device.get_type(), DeviceType::USB);
+    let apps = device.enumerate_applications(None, None);
+
+    if !apps.is_empty() {
+        // query detail of the first app
+        let identifier = apps[0].get_identifier();
+        let single = device.enumerate_applications(Some(&[identifier]), Some(Scope::Full));
+        let first = single.first().unwrap();
+        let params = first.get_parameters().unwrap();
+
+        println!("parameters of {}: ", first.get_identifier());
+        for (k, v) in params {
+            println!("{}: {:?}", k, v);
+        }
+    }
+
+    for a in apps {
+        println!("{} {} {:?}", a.get_name(), a.get_identifier(), a.get_pid());
+    }
+}

--- a/examples/core/get_apps/src/main.rs
+++ b/examples/core/get_apps/src/main.rs
@@ -18,6 +18,13 @@ fn main() {
         for (k, v) in params {
             println!("{}: {:?}", k, v);
         }
+
+        println!("---");
+
+        if let Some(frontmost) = device.frontmost_application(None) {
+            println!("frontmost: {} {} {:?}", frontmost.get_name(), frontmost.get_identifier(), frontmost.get_pid());
+            println!("---");
+        }
     }
 
     for a in apps {

--- a/examples/core/usb_device/src/main.rs
+++ b/examples/core/usb_device/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     let device_manager = frida::DeviceManager::obtain(&frida);
 
     // get the first usb device (assuming there is one attached)
-    let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    let device = device_manager.get_usb_device().unwrap();
     assert_eq!(device.get_type(), DeviceType::USB);
     println!(
         "found {} with type: {}",

--- a/frida/src/application.rs
+++ b/frida/src/application.rs
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2025 Zhi Zhou
+ *
+ * Licence: wxWindows Library Licence, Version 3.1
+ */
+
+use frida_sys::{
+    FridaApplicationQueryOptions, FridaScope_FRIDA_SCOPE_FULL, FridaScope_FRIDA_SCOPE_METADATA,
+    FridaScope_FRIDA_SCOPE_MINIMAL, _FridaApplication,
+};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+
+use crate::variant::Variant;
+use crate::Result;
+
+/// App management in Frida.
+pub struct Application<'a> {
+    application_ptr: *mut _FridaApplication,
+    phantom: PhantomData<&'a _FridaApplication>,
+}
+
+impl<'a> Application<'a> {
+    pub(crate) fn from_raw(application_ptr: *mut _FridaApplication) -> Application<'a> {
+        Application {
+            application_ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns the name of the application.
+    pub fn get_name(&self) -> &str {
+        let application_name = unsafe {
+            CStr::from_ptr(frida_sys::frida_application_get_name(self.application_ptr) as _)
+        };
+
+        application_name.to_str().unwrap_or_default()
+    }
+
+    /// Returns the identifier of the application.
+    pub fn get_identifier(&self) -> &str {
+        let application_identifier = unsafe {
+            CStr::from_ptr(frida_sys::frida_application_get_identifier(self.application_ptr) as _)
+        };
+
+        application_identifier.to_str().unwrap_or_default()
+    }
+
+    /// Returns the pid of the application.
+    pub fn get_pid(&self) -> u32 {
+        unsafe { frida_sys::frida_application_get_pid(self.application_ptr) }
+    }
+
+    /// Returns parameters of the application.
+    ///
+    ///
+    /// # Example
+    /// ```ignore
+    ///# use std::collections::HashMap;
+    ///# let frida = unsafe { frida::Frida::obtain() };
+    ///# let device_manager = frida::DeviceManager::obtain(&frida);
+    ///# let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    ///# let app = device.enumerate_applications().into_iter().find(|app| app.get_identifier() == "com.example.app").unwrap();
+    /// let params = app.get_parameters()
+    ///    .expect("Failed to get parameters");
+    /// ```
+    pub fn get_parameters(&self) -> Result<HashMap<String, Variant>> {
+        let ht = unsafe { frida_sys::frida_application_get_parameters(self.application_ptr) };
+        let mut iter: frida_sys::GHashTableIter =
+            unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+        unsafe { frida_sys::g_hash_table_iter_init(&mut iter, ht) };
+        let size = unsafe { frida_sys::g_hash_table_size(ht) };
+        let mut map = HashMap::with_capacity(size as usize);
+
+        let mut key = std::ptr::null_mut();
+        let mut val = std::ptr::null_mut();
+        while (unsafe { frida_sys::g_hash_table_iter_next(&mut iter, &mut key, &mut val) }
+            != frida_sys::FALSE as i32)
+        {
+            let key = unsafe { CStr::from_ptr(key as _) };
+            let val = unsafe { Variant::from_ptr(val as _) };
+            map.insert(key.to_string_lossy().to_string(), val);
+        }
+
+        Ok(map)
+    }
+}
+
+impl Drop for Application<'_> {
+    fn drop(&mut self) {
+        unsafe { frida_sys::frida_unref(self.application_ptr as _) }
+    }
+}
+
+/// Application Query Options
+pub struct ApplicationQueryOptions<'a> {
+    pub(crate) options_ptr: *mut FridaApplicationQueryOptions,
+    phantom: PhantomData<&'a FridaApplicationQueryOptions>,
+}
+
+impl ApplicationQueryOptions<'_> {
+    pub(crate) fn from_raw(options_ptr: *mut FridaApplicationQueryOptions) -> Self {
+        Self {
+            options_ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create an empty ApplicationQueryOptions instance
+    pub fn new() -> Self {
+        let options_ptr = unsafe { frida_sys::frida_application_query_options_new() };
+        Self::from_raw(options_ptr)
+    }
+
+    /// Set the scope of the query.
+    pub fn set_scope(&self, scope: u32) {
+        if scope != FridaScope_FRIDA_SCOPE_MINIMAL as u32
+            && scope != FridaScope_FRIDA_SCOPE_METADATA as u32
+            && scope != FridaScope_FRIDA_SCOPE_FULL as u32
+        {
+            panic!("Invalid scope value");
+        }
+
+        unsafe {
+            frida_sys::frida_application_query_options_set_scope(self.options_ptr, scope as _)
+        }
+    }
+
+    /// Append identifier to the query.
+    pub fn add_identifier(&self, identifier: &str) {
+        let identifier = CString::new(identifier).expect("Failed to convert identifier to CString");
+        unsafe {
+            frida_sys::frida_application_query_options_select_identifier(
+                self.options_ptr,
+                identifier.as_ptr(),
+            )
+        }
+    }
+}
+
+impl Drop for ApplicationQueryOptions<'_> {
+    fn drop(&mut self) {
+        unsafe { frida_sys::frida_unref(self.options_ptr as _) }
+    }
+}

--- a/frida/src/application.rs
+++ b/frida/src/application.rs
@@ -57,7 +57,7 @@ impl<'a> Application<'a> {
     ///# use std::collections::HashMap;
     ///# let frida = unsafe { frida::Frida::obtain() };
     ///# let device_manager = frida::DeviceManager::obtain(&frida);
-    ///# let device = device_manager.get_device_by_type(DeviceType::USB).unwrap();
+    ///# let device = device_manager.get_usb_device().unwrap();
     ///# let app = device.enumerate_applications().into_iter().find(|app| app.get_identifier() == "com.example.app").unwrap();
     /// let params = app.get_parameters()
     ///    .expect("Failed to get parameters");

--- a/frida/src/device_manager.rs
+++ b/frida/src/device_manager.rs
@@ -112,6 +112,11 @@ impl<'a> DeviceManager<'a> {
         self.get_device_by_type(device::DeviceType::Local)
     }
 
+    /// Returns usb device
+    pub fn get_usb_device(&'a self) -> Result<Device<'a>> {
+        self.get_device_by_type(device::DeviceType::USB)
+    }
+
     /// Returns the device with the specified id.
     ///
     /// # Example

--- a/frida/src/lib.rs
+++ b/frida/src/lib.rs
@@ -25,6 +25,9 @@ pub use error::Error;
 mod injector;
 pub use injector::*;
 
+mod application;
+pub use application::*;
+
 mod process;
 pub use process::*;
 


### PR DESCRIPTION
This PR implemented the following:

- application enumeration, with the support for scope and identifier query
- query parameter for an app (icon, container, etc)
- add a shortcut to get first usb device in device_manager