### PR TITLE
frida-gum-sys,frida-sys: bindgen w/ prettyplease

### DIFF
--- a/frida-gum-sys/build.rs
+++ b/frida-gum-sys/build.rs
@@ -78,7 +78,9 @@ fn main() {
         println!("cargo:rustc-link-lib=pthread");
     }
 
-    let bindings = bindgen::Builder::default().use_core();
+    let bindings = bindgen::Builder::default()
+        .use_core()
+        .formatter(bindgen::Formatter::Prettyplease);
 
     #[cfg(feature = "auto-download")]
     let bindings = bindings.clang_arg(format!("-I{include_dir}"));

--- a/frida-sys/build.rs
+++ b/frida-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
     };
 
     let bindings = bindings
+        .formatter(bindgen::Formatter::Prettyplease)
         .header_contents("core.h", "#include \"frida-core.h\"")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate_comments(false)


### PR DESCRIPTION
The generated bindings are otherwise a single line which is hard for vscode to open. It's useful to poke around in the bindings when playing with the APIs. Prettyplease is fast. I don't see a downside to always enabling it, and it was already enabled as a default feature of bindgen.