### PR TITLE
Fix build failure on nightly

### DIFF
--- a/frida-gum/src/interceptor/invocation_listener.rs
+++ b/frida-gum/src/interceptor/invocation_listener.rs
@@ -167,7 +167,7 @@ impl<'a> InvocationContext<'a> {
     }
 
     /// Get the [`CpuContext`] at the time of invocation.
-    pub fn cpu_context(&self) -> CpuContext {
+    pub fn cpu_context(&self) -> CpuContext<'_> {
         CpuContext::from_raw(unsafe { (*self.context).cpu_context })
     }
 }

--- a/frida-gum/src/script/scheduler.rs
+++ b/frida-gum/src/script/scheduler.rs
@@ -29,7 +29,7 @@ impl Scheduler {
     }
 
     pub fn get_context(&self) -> Context {
-        Context::from_raw(&self, unsafe {
+        Context::from_raw(self, unsafe {
             gum_script_scheduler_get_js_context(self.internal)
         })
     }


### PR DESCRIPTION
Fix the build failure due to a hidden lifetime, similar to #211 (https://github.com/frida/frida-rust/pull/211/files#diff-11501e57faea644796e9f839a366d147145263e93fee2c139bfab1f3a8d7bfc2) 

```
error: hiding a lifetime that's elided elsewhere is confusing
   --> frida-gum/src/interceptor/invocation_listener.rs:170:24
    |
170 |     pub fn cpu_context(&self) -> CpuContext {
    |                        ^^^^^     ---------- the same lifetime is hidden here
    |                        |
    |                        the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
note: the lint level is defined here
   --> frida-gum/src/lib.rs:49:9
    |
49  | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(mismatched_lifetime_syntaxes)]` implied by `#[deny(warnings)]`
help: use `'_` for type paths
    |
170 |     pub fn cpu_context(&self) -> CpuContext<'_> {
    |                                            ++++

error: could not compile `frida-gum` (lib) due to 1 previous error
```