### PR TITLE
Change Handler trait to receive message by value

### DIFF
--- a/examples/core/console_log/src/main.rs
+++ b/examples/core/console_log/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 struct Handler;
 
 impl ScriptHandler for Handler {
-    fn on_message(&mut self, message: &frida::Message, _data: Option<Vec<u8>>) {
+    fn on_message(&mut self, message: frida::Message, _data: Option<Vec<u8>>) {
         println!("{:?}", message);
     }
 }

--- a/examples/core/list_exports/src/main.rs
+++ b/examples/core/list_exports/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
 struct Handler;
 
 impl frida::ScriptHandler for Handler {
-    fn on_message(&mut self, message: &Message, _data: Option<Vec<u8>>) {
+    fn on_message(&mut self, message: Message, _data: Option<Vec<u8>>) {
         println!("- {:?}", message);
     }
 }

--- a/examples/core/rpc_execute_function/src/main.rs
+++ b/examples/core/rpc_execute_function/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
 struct Handler;
 
 impl frida::ScriptHandler for Handler {
-    fn on_message(&mut self, message: &Message, _data: Option<Vec<u8>>) {
+    fn on_message(&mut self, message: Message, _data: Option<Vec<u8>>) {
         println!("- {:?}", message);
     }
 }

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -121,7 +121,7 @@ unsafe extern "C" fn call_on_message<I: ScriptHandler>(
 
             // Retrieve extra message data, if any.
             if data.is_null() {
-                handler.on_message(&formatted_msg, None);
+                handler.on_message(formatted_msg, None);
                 return;
             }
 
@@ -140,7 +140,7 @@ unsafe extern "C" fn call_on_message<I: ScriptHandler>(
                         .to_vec(),
                 )
             };
-            handler.on_message(&formatted_msg, data_vec);
+            handler.on_message(formatted_msg, data_vec);
         }
     }
 }
@@ -153,7 +153,7 @@ fn on_message(cb_handler: &mut CallbackHandler, message: Message) {
 /// Represents a script signal handler.
 pub trait ScriptHandler {
     /// Handler called when a message is shared from JavaScript to Rust.
-    fn on_message(&mut self, message: &Message, data: Option<Vec<u8>>);
+    fn on_message(&mut self, message: Message, data: Option<Vec<u8>>);
 }
 
 /// Represents a Frida script.
@@ -234,7 +234,7 @@ impl<'a> Script<'a> {
     /// struct Handler;
     ///
     /// impl ScriptHandler for Handler {
-    ///     fn on_message(&mut self, message: &frida::Message, data: Option<Vec<u8>>) {
+    ///     fn on_message(&mut self, message: frida::Message, data: Option<Vec<u8>>) {
     ///         println!("Message: {:?}", message);
     ///         println!("Data: {:?}", data);
     ///     }


### PR DESCRIPTION
As discussed in #217, there’s no reason the message handler should only receive a reference to the message. Passing the value directly is more idiomatic in Rust and helps reduce memory allocation within the handler.

Although the Handler trait is public and changing the signature of its method constitutes a breaking change, the modification—both for us and for users—is straightforward. I believe it’s worth pursuing.