### PR TITLE
update examples to fix frida17 breaking change of module api 

### DIFF
--- a/examples/gum/debug_symbol/src/main.rs
+++ b/examples/gum/debug_symbol/src/main.rs
@@ -1,14 +1,12 @@
 use frida_gum::DebugSymbol;
 use frida_gum::{Gum, Module};
-use std::iter::Once;
 use std::sync::OnceLock;
 
 fn main() {
     static CELL: OnceLock<Gum> = OnceLock::new();
-    let gum = CELL.get_or_init(|| Gum::obtain());
+    let _gum = CELL.get_or_init(|| Gum::obtain());
 
-    let module = Module::obtain(gum);
-    let symbol = module.find_export_by_name(None, "mmap").unwrap();
+    let symbol = Module::find_global_export_by_name("mmap").unwrap();
     let symbol_details = DebugSymbol::from_address(symbol).unwrap();
     println!(
         "address={:#x?} module_name={:?} symbol_name={:?} file_name={:?} line_number={:?}",

--- a/examples/gum/hook_instruction/src/lib.rs
+++ b/examples/gum/hook_instruction/src/lib.rs
@@ -18,8 +18,7 @@ fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
     let mut interceptor = Interceptor::obtain(gum);
-    let module = Module::obtain(gum);
-    let open = module.find_export_by_name(None, "open").unwrap();
+    let open = Module::find_global_export_by_name("open").unwrap();
     let mut listener = OpenProbeListener;
     interceptor.attach_instruction(open, &mut listener).unwrap();
 }

--- a/examples/gum/hook_open/src/lib.rs
+++ b/examples/gum/hook_open/src/lib.rs
@@ -31,9 +31,8 @@ unsafe extern "C" fn open_detour(name: *const c_char, flags: c_int) -> c_int {
 fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
-    let module = Module::obtain(gum);
     let mut interceptor = Interceptor::obtain(gum);
-    let open = module.find_export_by_name(None, "open").unwrap();
+    let open = Module::find_global_export_by_name("open").unwrap();
     unsafe {
         *ORIGINAL_OPEN.lock().unwrap().get_mut() = Some(std::mem::transmute::<
             *mut libc::c_void,

--- a/examples/gum/open/Cargo.toml
+++ b/examples/gum/open/Cargo.toml
@@ -10,4 +10,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-frida-gum = { path = "../../../frida-gum", features = ["invocation-listener"] }
+frida-gum = { path = "../../../frida-gum", features = ["invocation-listener", "std"] }
+ctor = "0.2"

--- a/examples/gum/open/src/lib.rs
+++ b/examples/gum/open/src/lib.rs
@@ -1,9 +1,10 @@
 /* This example is in the public domain */
 
+use ctor::ctor;
 use frida_gum as gum;
 use gum::{
     interceptor::{Interceptor, InvocationContext, InvocationListener},
-    Gum, Module,
+    Gum, Module, Process,
 };
 use std::os::raw::{c_int, c_void};
 use std::sync::OnceLock;
@@ -30,15 +31,42 @@ extern "C" fn example_agent_main(_user_data: *const c_void, resident: *mut c_int
     let mut interceptor = Interceptor::obtain(gum);
     let mut listener = OpenListener {};
 
-    let module = Module::obtain(gum);
-    let modules = module.enumerate_modules();
+    let process = Process::obtain(gum);
+    let modules = process.enumerate_modules();
+
     for module in modules {
         println!(
             "{}@{:#x}/{:#x}",
-            module.name, module.base_address, module.size
+            module.name(),
+            module.range().base_address(),
+            module.range().size()
         );
     }
 
-    let open = module.find_export_by_name(None, "open").unwrap();
+    let open = Module::find_global_export_by_name("open").unwrap();
+    interceptor.attach(open, &mut listener).unwrap();
+}
+
+#[ctor]
+fn init() {
+    static CELL: OnceLock<Gum> = OnceLock::new();
+    let gum = CELL.get_or_init(|| Gum::obtain());
+
+    let mut interceptor = Interceptor::obtain(gum);
+    let mut listener = OpenListener {};
+
+    let process = Process::obtain(gum);
+    let modules = process.enumerate_modules();
+
+    for module in modules {
+        println!(
+            "{}@{:#x}/{:#x}",
+            module.name(),
+            module.range().base_address(),
+            module.range().size()
+        );
+    }
+
+    let open = Module::find_global_export_by_name("open").unwrap();
     interceptor.attach(open, &mut listener).unwrap();
 }

--- a/examples/gum/script/src/main.rs
+++ b/examples/gum/script/src/main.rs
@@ -28,11 +28,12 @@ pub fn main() {
     let payload = include_str!("script.js");
     println!("payload: {}", payload);
 
-    let backend = Backend::obtain_v8(&GUM);
+    let backend = Backend::obtain_qjs(&GUM);
     let script = Script::load(&backend, "script.js", payload, Some(callback)).unwrap();
 
     let t2 = test2(987);
     println!("TEST2: {}", t2);
+    test1(123);
 
     /* Run the loop to continue handling callbacks */
     script.run_event_loop();

--- a/examples/gum/script/src/script.js
+++ b/examples/gum/script/src/script.js
@@ -3,10 +3,10 @@ console.log("[*] Hello, world!");
 /* Test a message containing some bytes */
 send("message", [0x10, 0x20, 0x30, 0x40]);
 
-const test1 = Module.getExportByName(null, "test1");
+const test1 = Module.getGlobalExportByName("test1");
 console.log(`[*] test1: ${test1}`);
 
-const test2 = Module.getExportByName(null, "test2");
+const test2 = Module.getGlobalExportByName("test2");
 console.log(`[*] test2: ${test2}`);
 
 /* Call test1 from our script */
@@ -15,11 +15,13 @@ test1fn(123);
 
 /* Patch test2 from our script */
 Interceptor.attach(test2, {
-    onEnter: (args) => {
-        console.log("Entering test2");
-        args[0] = ptr(654);
-        console.log("Leaving test2");
-    },
+  onEnter: (args) => {
+    console.log("Entering test2");
+    args[0] = ptr(654);
+  },
+  onLeave: (retv) => {
+    console.log("Leaving test2");
+  },
 });
 
 console.log("Script Complete");


### PR DESCRIPTION
no longer Module.obtain()

module.find_export_by_name(null, "name") -> Module::find_global_export_by_name("name")

module.enumerate_modules() -> process.enumerate_modules()