### PR TITLE
Adding support for gum_backtracer_generate_with_limit in Backtrace

### DIFF
--- a/frida-gum/src/backtracer.rs
+++ b/frida-gum/src/backtracer.rs
@@ -33,18 +33,20 @@ extern "C" {
 pub struct Backtracer;
 
 impl Backtracer {
-    /// Generate a backtrace
-    fn generate(
+    /// Generate a backtrace stopping after 'limit' entries
+    fn generate_with_limit(
         backtracer: *mut gum_sys::GumBacktracer,
         context: *const gum_sys::GumCpuContext,
+        limit: gum_sys::guint,
     ) -> Vec<usize> {
         let mut return_address_array = MaybeUninit::<gum_sys::_GumReturnAddressArray>::uninit();
 
         unsafe {
-            gum_sys::gum_backtracer_generate(
+            gum_sys::gum_backtracer_generate_with_limit(
                 backtracer,
                 context,
                 return_address_array.as_mut_ptr(),
+                limit,
             );
             let return_address_array = return_address_array.assume_init();
             let mut result = vec![];
@@ -57,35 +59,69 @@ impl Backtracer {
 
     /// Generate an accurate backtrace as a list of return addresses from the current context
     pub fn accurate() -> Vec<usize> {
-        Self::generate(
+        Self::accurate_with_limit(gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate an accurate backtrace as a list of return addresses from the current context
+    /// stopping after 'limit' entries
+    pub fn accurate_with_limit(limit: u32) -> Vec<usize> {
+        Self::generate_with_limit(
             unsafe { gum_sys::gum_backtracer_make_accurate() },
             core::ptr::null(),
+            limit,
         )
     }
 
     /// Generate a fuzzy backtrace as a list of return addresses from the current context
     pub fn fuzzy() -> Vec<usize> {
-        Self::generate(
+        Self::fuzzy_with_limit(gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate a fuzzy backtrace as a list of return addresses from the current context stopping
+    /// after 'limit' entries.
+    pub fn fuzzy_with_limit(limit: u32) -> Vec<usize> {
+        Self::generate_with_limit(
             unsafe { gum_sys::gum_backtracer_make_fuzzy() },
             core::ptr::null(),
+            limit,
         )
     }
 
     /// Generate an accurate backtrace as a list of return addresses for the supplied cpu
     /// context.
     pub fn accurate_with_context(context: &gum_sys::GumCpuContext) -> Vec<usize> {
-        Self::generate(
+        Self::accurate_with_context_and_limit(context, gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate an accurate backtrace as a list of return addresses for the supplied cpu
+    /// context stopping after 'limit' entries.
+    pub fn accurate_with_context_and_limit(
+        context: &gum_sys::GumCpuContext,
+        limit: u32,
+    ) -> Vec<usize> {
+        Self::generate_with_limit(
             unsafe { gum_sys::gum_backtracer_make_accurate() },
             context as *const gum_sys::GumCpuContext,
+            limit,
         )
     }
 
     /// Generate a fuzzy backtrace as a list of return addresses for the supplied cpu
     /// context.
     pub fn fuzzy_with_context(context: &gum_sys::GumCpuContext) -> Vec<usize> {
-        Self::generate(
+        Self::fuzzy_with_context_and_limit(&context, gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate a fuzzy backtrace as a list of return addresses for the supplied cpu
+    /// context stopping after 'limit' entries.
+    pub fn fuzzy_with_context_and_limit(
+        context: &gum_sys::GumCpuContext,
+        limit: u32,
+    ) -> Vec<usize> {
+        Self::generate_with_limit(
             unsafe { gum_sys::gum_backtracer_make_fuzzy() },
             context as *const gum_sys::GumCpuContext,
+            limit,
         )
     }
 
@@ -93,6 +129,16 @@ impl Backtracer {
     /// context.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     pub fn accurate_with_signal_context(context: &libc::ucontext_t) -> Vec<usize> {
+        Self::accurate_with_signal_context_and_limit(context, gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate an accurate backtrace as a list of return addresses for the supplied signal
+    /// context stopping after 'limit' entries.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub fn accurate_with_signal_context_and_limit(
+        context: &libc::ucontext_t,
+        limit: u32,
+    ) -> Vec<usize> {
         let mut cpu_context = MaybeUninit::<gum_sys::GumCpuContext>::uninit();
 
         unsafe {
@@ -103,14 +149,25 @@ impl Backtracer {
                 context as *const libc::ucontext_t,
                 cpu_context.as_mut_ptr(),
             );
-            Self::accurate_with_context(&cpu_context.assume_init())
+            Self::accurate_with_context_and_limit(&cpu_context.assume_init(), limit)
         }
     }
 
     /// Generate a fuzzy backtrace as a list of return addresses for the supplied signal
     /// context.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+
     pub fn fuzzy_with_signal_context(context: &libc::ucontext_t) -> Vec<usize> {
+        Self::fuzzy_with_signal_context_and_limit(context, gum_sys::GUM_MAX_BACKTRACE_DEPTH)
+    }
+
+    /// Generate a fuzzy backtrace as a list of return addresses for the supplied signal
+    /// context stopping after 'limit' entries
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub fn fuzzy_with_signal_context_and_limit(
+        context: &libc::ucontext_t,
+        limit: u32,
+    ) -> Vec<usize> {
         let mut cpu_context = MaybeUninit::<gum_sys::GumCpuContext>::uninit();
 
         unsafe {
@@ -121,7 +178,7 @@ impl Backtracer {
                 context as *const libc::ucontext_t,
                 cpu_context.as_mut_ptr(),
             );
-            Self::fuzzy_with_context(&cpu_context.assume_init())
+            Self::fuzzy_with_context_and_limit(&cpu_context.assume_init(), limit)
         }
     }
 }

--- a/frida-gum/src/cpu_context.rs
+++ b/frida-gum/src/cpu_context.rs
@@ -107,4 +107,18 @@ impl<'a> CpuContext<'a> {
     pub fn backtrace_fuzzy(&self) -> Vec<usize> {
         crate::Backtracer::fuzzy_with_context(unsafe { &*self.cpu_context })
     }
+
+    #[cfg(feature = "backtrace")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "backtrace")))]
+    /// Get an accurate backtrace from this CPU context.
+    pub fn backtrace_accurate_with_limit(&self, limit: u32) -> Vec<usize> {
+        crate::Backtracer::accurate_with_context_and_limit(unsafe { &*self.cpu_context }, limit)
+    }
+
+    #[cfg(feature = "backtrace")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "backtrace")))]
+    /// Get a fuzzy backtrace from this CPU context.
+    pub fn backtrace_fuzzy_with_limit(&self, limit: u32) -> Vec<usize> {
+        crate::Backtracer::fuzzy_with_context_and_limit(unsafe { &*self.cpu_context }, limit)
+    }
 }


### PR DESCRIPTION
Adding support for `gum_backtracer_generate_with_limit` in `Backtracer`

Normally we will get the full bt but for large nested calls into hot functions this can become a pain if we wanted just a few levels

`gum_backtracer_generate` is basically a call to `gum_backtracer_generate_with_limit` with `GUM_MAX_BACKTRACE_DEPTH` as limit: [https://github.com/frida/frida-gum/blob/5ee7ae3f1719db72b0b621f660d3a2fff4d045a4/gum/gumbacktracer.c#L129](https://github.com/frida/frida-gum/blob/5ee7ae3f1719db72b0b621f660d3a2fff4d045a4/gum/gumbacktracer.c#L129) so I reflected this in the code as well

