### PR TITLE
Fix hook Module related examples

### DIFF
--- a/examples/gum/hook_instruction/src/lib.rs
+++ b/examples/gum/hook_instruction/src/lib.rs
@@ -18,8 +18,8 @@ fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
     let mut interceptor = Interceptor::obtain(gum);
-    let module = Module::obtain(gum);
-    let open = module.find_export_by_name(None, "open").unwrap();
+    let module = Module::load(gum, "libc.so.6");
+    let open = module.find_export_by_name("open").unwrap();
     let mut listener = OpenProbeListener;
     interceptor.attach_instruction(open, &mut listener).unwrap();
 }

--- a/examples/gum/hook_open/README.md
+++ b/examples/gum/hook_open/README.md
@@ -3,9 +3,17 @@
 This is an example on how to hook "open" libc function using frida-rust.
 
 ### Linux
+
 To test this on Linux, run a binary that calls "open" with this library LD_PRELOAD-ed:
-`LD_PRELOAD=hook_openlib.so cat /tmp/test"
+
+```sh
+LD_PRELOAD=../../../target/release/libhook_open.so cat /tmp/test
+```
 
 ### MacOS
+
 Find a binary that supports `DYLD_INSERT_LIBRARIES` and call it
-`DYLD_INSERT_LIBRARIES=hook_openlib.so somebinary"
+
+```sh
+DYLD_INSERT_LIBRARIES=hook_openlib.so somebinary"
+```

--- a/examples/gum/hook_open/src/lib.rs
+++ b/examples/gum/hook_open/src/lib.rs
@@ -31,9 +31,9 @@ unsafe extern "C" fn open_detour(name: *const c_char, flags: c_int) -> c_int {
 fn init() {
     static CELL: OnceLock<Gum> = OnceLock::new();
     let gum = CELL.get_or_init(|| Gum::obtain());
-    let module = Module::obtain(gum);
+    let module = Module::load(gum, "libc.so.6");
     let mut interceptor = Interceptor::obtain(gum);
-    let open = module.find_export_by_name(None, "open").unwrap();
+    let open = module.find_export_by_name("open").unwrap();
     unsafe {
         *ORIGINAL_OPEN.lock().unwrap().get_mut() = Some(std::mem::transmute::<
             *mut libc::c_void,


### PR DESCRIPTION
`Module` doesn't use `obtain` anymore. Using `load` instead.

Tested on Linux.