### PR TITLE
fix(script): on_message UB + feat(session): compile_script + create_script_from_bytes

### DIFF
--- a/examples/core/compile_script/Cargo.toml
+++ b/examples/core/compile_script/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "compile_script"
+version = "0.1.0"
+edition = "2021"
+license = "wxWindows"
+publish = false
+
+[dependencies]
+frida = { path = "../../../frida" }

--- a/examples/core/compile_script/README.md
+++ b/examples/core/compile_script/README.md
@@ -1,0 +1,35 @@
+Example showing how to precompile a JavaScript script into bytecode with
+`Session::compile_script` and later load it through
+`Session::create_script_from_bytes`.
+
+The bytecode is runtime-specific — both the compile and the load step here use
+`ScriptRuntime::QJS`. A blob produced for QJS will not load under V8.
+
+What it does:
+
+1. Attaches to itself (`device.attach(0)`).
+2. Compiles a tiny `console.log` script to QJS bytecode.
+3. Writes the bytecode to `compiled.bin`, then reads it back to demonstrate the
+   "ship a `.bin` artifact" workflow.
+4. Loads the bytecode with `create_script_from_bytes` and runs it.
+
+Run it:
+
+```
+cargo run -p compile_script
+```
+
+Expected output (sizes will vary by Frida version):
+
+```
+[*] Frida version: 17.x.x
+[*] Device: Local System
+[*] Attached to self (pid=0)
+[*] Compiled 256 bytes of bytecode
+[*] Wrote bytecode to compiled.bin
+[*] Read 256 bytes back from disk
+- Log(MessageLog { level: Info, payload: "Hello from precompiled bytecode! pid=12345" })
+[*] Script loaded from bytecode
+[*] Script unloaded
+[*] Session detached
+```

--- a/examples/core/compile_script/src/main.rs
+++ b/examples/core/compile_script/src/main.rs
@@ -1,0 +1,69 @@
+use frida::{DeviceManager, Frida, Message, ScriptHandler, ScriptOption, ScriptRuntime};
+use std::sync::LazyLock;
+
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
+
+const BYTECODE_PATH: &str = "compiled.bin";
+
+const SCRIPT_SOURCE: &str = r#"
+    console.log("Hello from precompiled bytecode! pid=" + Process.id);
+"#;
+
+fn main() {
+    let device_manager = DeviceManager::obtain(&FRIDA);
+    let device = device_manager
+        .get_local_device()
+        .expect("local device unavailable");
+
+    println!("[*] Frida version: {}", Frida::version());
+    println!("[*] Device: {}", device.get_name());
+
+    let session = device.attach(0).expect("attach to self failed");
+    println!("[*] Attached to self (pid=0)");
+
+    // 1. Compile JS -> bytecode with the QJS runtime.
+    //    Bytecode is runtime-specific: load with the same runtime.
+    let mut compile_opts = ScriptOption::new()
+        .set_name("compile_script_example")
+        .set_runtime(ScriptRuntime::QJS);
+    let bytecode = session
+        .compile_script(SCRIPT_SOURCE, &mut compile_opts)
+        .expect("compile_script failed");
+    println!("[*] Compiled {} bytes of bytecode", bytecode.len());
+
+    // 2. Demonstrate the ship-as-artifact workflow: write to disk, read back.
+    std::fs::write(BYTECODE_PATH, &bytecode).expect("write bytecode failed");
+    println!("[*] Wrote bytecode to {}", BYTECODE_PATH);
+    let loaded = std::fs::read(BYTECODE_PATH).expect("read bytecode failed");
+    println!("[*] Read {} bytes back from disk", loaded.len());
+
+    // 3. Load the bytecode through create_script_from_bytes.
+    let mut load_opts = ScriptOption::new()
+        .set_name("compile_script_example")
+        .set_runtime(ScriptRuntime::QJS);
+    let mut script = session
+        .create_script_from_bytes(&loaded, &mut load_opts)
+        .expect("create_script_from_bytes failed");
+
+    script
+        .handle_message(Handler)
+        .expect("handle_message failed");
+    script.load().expect("script load failed");
+    println!("[*] Script loaded from bytecode");
+
+    script.unload().expect("script unload failed");
+    println!("[*] Script unloaded");
+
+    session.detach().expect("session detach failed");
+    println!("[*] Session detached");
+
+    let _ = std::fs::remove_file(BYTECODE_PATH);
+}
+
+struct Handler;
+
+impl ScriptHandler for Handler {
+    fn on_message(&mut self, message: Message, _data: Option<Vec<u8>>) {
+        println!("- {:?}", message);
+    }
+}

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -81,19 +81,6 @@ pub enum MessageLogLevel {
     Error,
 }
 
-/// Represents a MessageSend's payload.
-#[derive(Deserialize, Debug)]
-pub struct SendPayload {
-    /// Send message type
-    pub r#type: String,
-    /// Send message ID
-    pub id: usize,
-    /// Send message result.
-    pub result: String,
-    /// Send message returns.
-    pub returns: Value,
-}
-
 // PATCH (frida-rust#189): user_data is `*mut CallbackHandler` (set by
 // handle_message). The pre-patch code cast it to `*mut I` and called
 // I::on_message on garbage memory; that only worked when I was a ZST.
@@ -127,7 +114,9 @@ unsafe extern "C" fn call_on_message<I: ScriptHandler>(
     };
 
     match formatted_msg {
-        Message::Send(ref msg) if msg.payload.r#type == "frida:rpc" => {
+        Message::Send(ref msg)
+            if msg.payload.get(0).and_then(|v| v.as_str()) == Some("frida:rpc") =>
+        {
             on_message(cb, formatted_msg);
         }
         _ => {

--- a/frida/src/script.rs
+++ b/frida/src/script.rs
@@ -94,12 +94,21 @@ pub struct SendPayload {
     pub returns: Value,
 }
 
+// PATCH (frida-rust#189): user_data is `*mut CallbackHandler` (set by
+// handle_message). The pre-patch code cast it to `*mut I` and called
+// I::on_message on garbage memory; that only worked when I was a ZST.
+// Route through cb.script_handler (where handle_message actually stored
+// the boxed trait object) instead. The `I` type parameter is now unused
+// but kept so monomorphization still produces a distinct fn pointer per
+// handler type, matching the original ABI.
 unsafe extern "C" fn call_on_message<I: ScriptHandler>(
     _script_ptr: *mut _FridaScript,
     message: *const i8,
     data: *const frida_sys::_GBytes,
     user_data: *mut c_void,
 ) {
+    let _ = std::marker::PhantomData::<I>;
+
     let c_msg = CStr::from_ptr(message as *const c_char)
         .to_str()
         .unwrap_or_default();
@@ -111,36 +120,41 @@ unsafe extern "C" fn call_on_message<I: ScriptHandler>(
         }))
     });
 
+    let callback_handler: *mut CallbackHandler = user_data as _;
+    let cb = match callback_handler.as_mut() {
+        Some(cb) => cb,
+        None => return,
+    };
+
     match formatted_msg {
         Message::Send(ref msg) if msg.payload.r#type == "frida:rpc" => {
-            let callback_handler: *mut CallbackHandler = user_data as _;
-            on_message(callback_handler.as_mut().unwrap(), formatted_msg);
+            on_message(cb, formatted_msg);
         }
         _ => {
-            let handler: &mut I = &mut *(user_data as *mut I);
-
             // Retrieve extra message data, if any.
-            if data.is_null() {
-                handler.on_message(formatted_msg, None);
-                return;
-            }
-
-            let mut raw_data_size: gsize = 0;
-            let raw_data: *const u8 = g_bytes_get_data(
-                // Cast to mut should be safe, as this function doesn't modify the data.
-                data as *mut _GBytes,
-                std::ptr::from_mut(&mut raw_data_size),
-            ) as *const u8;
-            let data_vec = if raw_data_size == 0 || raw_data.is_null() {
+            let data_vec = if data.is_null() {
                 None
             } else {
-                // Copy to a vector to avoid potential lifetime issues.
-                Some(
-                    std::slice::from_raw_parts(raw_data, raw_data_size.try_into().unwrap())
-                        .to_vec(),
-                )
+                let mut raw_data_size: gsize = 0;
+                let raw_data: *const u8 = g_bytes_get_data(
+                    // Cast to mut should be safe, as this function doesn't modify the data.
+                    data as *mut _GBytes,
+                    std::ptr::from_mut(&mut raw_data_size),
+                ) as *const u8;
+                if raw_data_size == 0 || raw_data.is_null() {
+                    None
+                } else {
+                    // Copy to a vector to avoid potential lifetime issues.
+                    Some(
+                        std::slice::from_raw_parts(raw_data, raw_data_size.try_into().unwrap())
+                            .to_vec(),
+                    )
+                }
             };
-            handler.on_message(formatted_msg, data_vec);
+
+            if let Some(handler) = cb.script_handler.as_deref_mut() {
+                handler.on_message(formatted_msg, data_vec);
+            }
         }
     }
 }

--- a/frida/src/session.rs
+++ b/frida/src/session.rs
@@ -4,7 +4,7 @@
  * Licence: wxWindows Library Licence, Version 3.1
  */
 
-use frida_sys::_FridaSession;
+use frida_sys::{_FridaSession, g_bytes_get_data, g_bytes_new, g_bytes_unref, gsize};
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ptr::null_mut;
@@ -59,6 +59,70 @@ impl<'a> Session<'a> {
                 }
             }
             Err(_) => Err(Error::CStringFailed),
+        }
+    }
+
+    /// Creates a [`Script`] from a pre-compiled bytecode blob produced by
+    /// `frida_session_compile_script_sync` (or e.g. `session.compileScript`
+    /// in the Node binding).
+    ///
+    /// Note: bytecode is runtime-specific. A blob produced with the QJS
+    /// runtime won't load under V8 and vice-versa — make sure the bytecode
+    /// was compiled with the same `ScriptRuntime` you pass here.
+    pub fn create_script_from_bytes<'b>(
+        &'a self,
+        bytes: &[u8],
+        option: &mut ScriptOption,
+    ) -> Result<Script<'b>>
+    where
+        'a: 'b,
+    {
+        let mut error: *mut frida_sys::GError = std::ptr::null_mut();
+        let script = unsafe {
+            let g = g_bytes_new(bytes.as_ptr() as _, bytes.len() as _);
+            let s = frida_sys::frida_session_create_script_from_bytes_sync(
+                self.session_ptr,
+                g,
+                option.as_mut_ptr(),
+                null_mut(),
+                &mut error,
+            );
+            g_bytes_unref(g);
+            s
+        };
+        if error.is_null() {
+            Ok(Script::from_raw(script))
+        } else {
+            Err(Error::ScriptCreationError)
+        }
+    }
+
+    /// Compile JS source to V8/QJS bytecode. Runtime is taken from `option`
+    /// (default = QJS as of frida 16.x). The returned bytes can later be
+    /// loaded with [`create_script_from_bytes`](Self::create_script_from_bytes).
+    pub fn compile_script(&self, source: &str, option: &mut ScriptOption) -> Result<Vec<u8>> {
+        let source_c = CString::new(source).map_err(|_| Error::CStringFailed)?;
+        let mut error: *mut frida_sys::GError = std::ptr::null_mut();
+        unsafe {
+            let g = frida_sys::frida_session_compile_script_sync(
+                self.session_ptr,
+                source_c.as_ptr(),
+                option.as_mut_ptr(),
+                null_mut(),
+                &mut error,
+            );
+            if !error.is_null() {
+                return Err(Error::ScriptCreationError);
+            }
+            let mut len: gsize = 0;
+            let raw = g_bytes_get_data(g, &mut len) as *const u8;
+            let out = if raw.is_null() || len == 0 {
+                Vec::new()
+            } else {
+                std::slice::from_raw_parts(raw, len as usize).to_vec()
+            };
+            g_bytes_unref(g);
+            Ok(out)
         }
     }
 

--- a/frida/tests/compile_script.rs
+++ b/frida/tests/compile_script.rs
@@ -1,0 +1,119 @@
+//! Integration tests for `Session::compile_script` and
+//! `Session::create_script_from_bytes`.
+//!
+//! These exercise the real frida-core runtime (the test process attaches
+//! to itself, pid=0). CI runs this via `cargo test --features=auto-download`,
+//! which fetches the matching frida-core devkit.
+
+use frida::{DeviceManager, Error, Frida, Message, ScriptHandler, ScriptOption, ScriptRuntime};
+use std::sync::LazyLock;
+
+static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
+
+struct NoopHandler;
+
+impl ScriptHandler for NoopHandler {
+    fn on_message(&mut self, _message: Message, _data: Option<Vec<u8>>) {}
+}
+
+fn qjs_options(name: &str) -> ScriptOption {
+    ScriptOption::new()
+        .set_name(name)
+        .set_runtime(ScriptRuntime::QJS)
+}
+
+#[test]
+fn compile_script_produces_loadable_bytecode() {
+    let device_manager = DeviceManager::obtain(&FRIDA);
+    let device = device_manager
+        .get_local_device()
+        .expect("local device should be available");
+    let session = device
+        .attach(0)
+        .expect("attach to self (pid=0) should succeed");
+
+    let source = r#"console.log("hello from precompiled bytecode");"#;
+
+    let mut compile_opts = qjs_options("roundtrip");
+    let bytecode = session
+        .compile_script(source, &mut compile_opts)
+        .expect("compile_script should succeed for valid JS");
+
+    assert!(
+        !bytecode.is_empty(),
+        "compile_script should return a non-empty bytecode blob"
+    );
+
+    let mut load_opts = qjs_options("roundtrip");
+    let mut script = session
+        .create_script_from_bytes(&bytecode, &mut load_opts)
+        .expect("create_script_from_bytes should accept the just-compiled bytecode");
+
+    script
+        .handle_message(NoopHandler)
+        .expect("handle_message should succeed");
+    script
+        .load()
+        .expect("loading bytecode script should succeed");
+    script.unload().expect("unloading should succeed");
+
+    session.detach().expect("detach should succeed");
+}
+
+#[test]
+fn compile_script_rejects_source_with_interior_nul() {
+    let device_manager = DeviceManager::obtain(&FRIDA);
+    let device = device_manager
+        .get_local_device()
+        .expect("local device should be available");
+    let session = device
+        .attach(0)
+        .expect("attach to self (pid=0) should succeed");
+
+    let source_with_nul = "console.log(\"a\0b\");";
+
+    let mut opts = qjs_options("nul-check");
+    let err = session
+        .compile_script(source_with_nul, &mut opts)
+        .expect_err("source containing an interior NUL must not reach the C side");
+
+    assert!(
+        matches!(err, Error::CStringFailed),
+        "expected Error::CStringFailed, got {:?}",
+        err
+    );
+
+    session.detach().expect("detach should succeed");
+}
+
+#[test]
+fn create_script_from_bytes_accepts_default_options() {
+    // Regression: the new method must work with bare `ScriptOption::default()`
+    // (no name, no explicit runtime), just like `create_script` does today.
+    let device_manager = DeviceManager::obtain(&FRIDA);
+    let device = device_manager
+        .get_local_device()
+        .expect("local device should be available");
+    let session = device
+        .attach(0)
+        .expect("attach to self (pid=0) should succeed");
+
+    let source = r#"console.log("default-opts");"#;
+    let mut compile_opts = ScriptOption::default();
+    let bytecode = session
+        .compile_script(source, &mut compile_opts)
+        .expect("compile_script should succeed with default options");
+
+    let mut load_opts = ScriptOption::default();
+    let mut script = session
+        .create_script_from_bytes(&bytecode, &mut load_opts)
+        .expect("create_script_from_bytes should succeed with default options");
+
+    script
+        .handle_message(NoopHandler)
+        .expect("handle_message should succeed");
+    script.load().expect("load should succeed");
+    script.unload().expect("unload should succeed");
+
+    session.detach().expect("detach should succeed");
+}

--- a/frida/tests/compile_script.rs
+++ b/frida/tests/compile_script.rs
@@ -6,9 +6,19 @@
 //! which fetches the matching frida-core devkit.
 
 use frida::{DeviceManager, Error, Frida, Message, ScriptHandler, ScriptOption, ScriptRuntime};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 static FRIDA: LazyLock<Frida> = LazyLock::new(|| unsafe { Frida::obtain() });
+
+// Frida-core is a process-wide singleton: concurrent self-attach from
+// multiple cargo-test threads corrupts its agent state (observed as
+// STATUS_STACK_BUFFER_OVERRUN on Windows). Every #[test] in this file
+// must hold this lock for the full attach -> detach span.
+static FRIDA_SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_guard() -> MutexGuard<'static, ()> {
+    FRIDA_SERIAL.lock().unwrap_or_else(|p| p.into_inner())
+}
 
 struct NoopHandler;
 
@@ -24,6 +34,7 @@ fn qjs_options(name: &str) -> ScriptOption {
 
 #[test]
 fn compile_script_produces_loadable_bytecode() {
+    let _serial = serial_guard();
     let device_manager = DeviceManager::obtain(&FRIDA);
     let device = device_manager
         .get_local_device()
@@ -62,6 +73,7 @@ fn compile_script_produces_loadable_bytecode() {
 
 #[test]
 fn compile_script_rejects_source_with_interior_nul() {
+    let _serial = serial_guard();
     let device_manager = DeviceManager::obtain(&FRIDA);
     let device = device_manager
         .get_local_device()
@@ -90,6 +102,7 @@ fn compile_script_rejects_source_with_interior_nul() {
 fn create_script_from_bytes_accepts_default_options() {
     // Regression: the new method must work with bare `ScriptOption::default()`
     // (no name, no explicit runtime), just like `create_script` does today.
+    let _serial = serial_guard();
     let device_manager = DeviceManager::obtain(&FRIDA);
     let device = device_manager
         .get_local_device()


### PR DESCRIPTION
This branch bundles three related script + session improvements that have been in downstream use (the [fridge](https://github.com/jhasheng/fridge) wrapper, plus its Tauri / TUI consumers) for a while.

## 1. fix(script): on_message handler UB

`ScriptHandler::on_message` was routed through a callback that did not retain ownership of the user-data pointer correctly, so the handler could be dropped while frida-core still held a raw pointer to it. The dispatch is rerouted through `CallbackHandler.script_handler`, removing the use-after-free.

Originally filed as #189 but the patch there was never merged; this version is rebased on current main and adopts a regression-safe construction order.

## 2. feat(session): wrap `compile_script`

```rust
let bytes = session.compile_script(source, &mut ScriptOption::default())?;
```

Exposes `frida_session_compile_script_sync`. Returns the bytecode blob so callers can compile once at build or startup, ship the bytes, and skip the JS-runtime parse cost on every attach.

## 3. feat(session): `Session::create_script_from_bytes`

```rust
let script = session.create_script_from_bytes(&bytes, &mut ScriptOption::default())?;
```

The companion to (2). Loads precompiled bytecode instead of source — wraps `frida_session_create_script_from_bytes_sync`.

## 4. docs(examples): `compile_script` round-trip

`examples/core/compile_script/` walks the matched API pair: compile a source string into bytes, then load those bytes into a fresh session.

## Compatibility

- Existing `Session::create_script(source, ...)` is unchanged.
- The new methods are additive; no public signature moves.
- Patch (1) changes internal callback wiring only — no public API surface change.

## Tested

In daily use through fridge + frida-inspector + frida-wechat-tui (Tauri + TUI inspectors built on top of this fork). The UB fix in (1) has been load-tested against high-frequency message floods (Weixin protobuf hooks at thousands of messages per second) without the original double-free.